### PR TITLE
Flip irregular particles

### DIFF
--- a/magpiem/cpp/processing.cpp
+++ b/magpiem/cpp/processing.cpp
@@ -18,6 +18,11 @@ enum LogLevel {
 
 static LogLevel g_log_level = LOG_WARNING;
 
+// Forward declaration for template function
+template<typename ParticlePtrType>
+void perform_flip_detection(const std::vector<Particle>& particles, const std::map<unsigned int, std::vector<ParticlePtrType>>& lattice_groups, 
+                           const CleanParams* params, int* flipped_results);
+
 void log_message(LogLevel level, const char* format, ...) {
     if (level < g_log_level) {
         return; 
@@ -335,7 +340,7 @@ void clean_and_detect_flips(float* data, int num_particles, CleanParams* params,
 }
 
 // Debug function for testing flip detection with manual lattice assignment
-void debug_flip_detection(float* data, int num_particles, CleanParams* params, int* lattice_results, int* flipped_results) {
+void debug_flip_detection(float* data, int num_particles, CleanParams* params, int* lattice_results, int* flipped_results) noexcept(false) {
     log_message(LOG_INFO, "Running debug flip detection on %d particles", num_particles);
     
     // Initialize all particles as not flipped and assign to lattice 1

--- a/magpiem/cpp/processing.cpp
+++ b/magpiem/cpp/processing.cpp
@@ -270,6 +270,11 @@ public:
             }
         }
     }
+
+    // Get access to the processed particles (for flip detection)
+    const std::vector<Particle>& get_particles() const {
+        return particles;
+    }
 };
 
 // Global instance for the particle processor
@@ -296,6 +301,131 @@ void clean_particles(float* data, int num_particles, CleanParams* params, int* r
     g_processor.clean_particles(data, num_particles, params, results);
 }
 
+void clean_and_detect_flips(float* data, int num_particles, CleanParams* params, int* lattice_results, int* flipped_results) {
+    log_message(LOG_INFO, "Running combined cleaning and flip detection on %d particles", num_particles);
+    
+    // First run the normal cleaning pipeline - this is the key part!
+    g_processor.clean_particles(data, num_particles, params, lattice_results);
+    
+    // Initialize all particles as not flipped
+    for (int i = 0; i < num_particles; i++) {
+        flipped_results[i] = 0;
+    }
+    
+    // Only run flip detection if allow_flips is enabled
+    if (!params->allow_flips) {
+        log_message(LOG_WARNING, "Flip detection was called, but flips were not allowed in cleaning params. This is likely incorrect.");
+        return;
+    }
+    
+    // processed particles already have assigned neighbours and lattices 
+    const std::vector<Particle>& particles = get_processed_particles();
+    
+    std::map<unsigned int, std::vector<const Particle*>> lattice_groups;
+    for (const auto& particle : particles) {
+        if (particle.lattice > 0) {
+            lattice_groups[particle.lattice].push_back(&particle);
+        }
+    }
+    
+    log_message(LOG_DEBUG, "Processing %zu lattice groups for flip detection", lattice_groups.size());
+    perform_flip_detection(particles, lattice_groups, params, flipped_results);
+    
+    log_message(LOG_INFO, "Flip detection completed");
+}
+
+// Debug function for testing flip detection with manual lattice assignment
+void debug_flip_detection(float* data, int num_particles, CleanParams* params, int* lattice_results, int* flipped_results) {
+    log_message(LOG_INFO, "Running debug flip detection on %d particles", num_particles);
+    
+    // Initialize all particles as not flipped and assign to lattice 1
+    for (int i = 0; i < num_particles; i++) {
+        flipped_results[i] = 0;
+        lattice_results[i] = 1; // All particles go to lattice 1
+    }
+    
+    // Only run flip detection if allow_flips is enabled
+    if (!params->allow_flips) {
+        throw std::invalid_argument( "Attempted to test flip detection with flip detection disabled in cleaning params (allow_flips=False).");
+        return;
+    }
+    
+    // Find neighbours. No additional cleaning to ensure all particles included in debugging
+    g_processor.find_neighbours(data, num_particles, params->min_distance, params->max_distance, lattice_results);
+    
+    // Get the particles with their neighbours already set
+    const std::vector<Particle>& particles = get_processed_particles();
+    
+    // Group all particles into lattice 1 for testing
+    std::map<unsigned int, std::vector<const Particle*>> lattice_groups;
+    for (const auto& particle : particles) {
+        lattice_groups[1].push_back(&particle);
+    }
+    
+    perform_flip_detection(particles, lattice_groups, params, flipped_results);
+    
+    log_message(LOG_INFO, "Debug flip detection completed");
+}
+
+template<typename ParticlePtrType>
+void perform_flip_detection(const std::vector<Particle>& particles, const std::map<unsigned int, std::vector<ParticlePtrType>>& lattice_groups, 
+                           const CleanParams* params, int* flipped_results) {
+    for (auto& [lattice_id, lattice_particles] : lattice_groups) {
+        if (lattice_particles.size() < 3) {
+            continue; // Need at least 3 particles
+        }
+        
+        // Use a map to store direction assignments (1 or -1)
+        std::map<ParticlePtrType, int> directions;
+        
+        // Start with first particle and assign arbitrarydirection
+        ParticlePtrType random_particle = lattice_particles[0];
+        directions[random_particle] = 1;
+        
+        // Recursively assign directions using BFS
+        std::vector<ParticlePtrType> to_process = {random_particle};
+        while (!to_process.empty()) {
+            ParticlePtrType current = to_process.back();
+            to_process.pop_back();
+            
+            for (ParticlePtrType neighbour : current->neighbours) {
+                if (directions.find(neighbour) == directions.end()) {
+                    float dot_prod = Particle::dot_product(current->orientation, neighbour->orientation);
+                    if (dot_prod >= params->min_orientation && dot_prod <= params->max_orientation) {
+                        // Aligned orientation: same direction
+                        directions[neighbour] = directions[current];
+                    } else {
+                        // Not aligned: opposite direction
+                        directions[neighbour] = -directions[current];
+                    }
+                    to_process.push_back(neighbour);
+                }
+            }
+        }
+        
+        // Count parallel vs antiparallel particles
+        int parallel_count = 0;
+        int antiparallel_count = 0;
+        for (ParticlePtrType particle : lattice_particles) {
+            if (directions[particle] > 0) {
+                parallel_count++;
+            } else {
+                antiparallel_count++;
+            }
+        }
+        
+        // Mark the minority group as flipped
+        bool mark_parallel_as_flipped = (parallel_count < antiparallel_count);
+        for (ParticlePtrType particle : lattice_particles) {
+            bool is_parallel = (directions[particle] > 0);
+            int particle_index = static_cast<int>(particle - &particles[0]);
+            if ((mark_parallel_as_flipped && is_parallel) || (!mark_parallel_as_flipped && !is_parallel)) {
+                flipped_results[particle_index] = 1;
+            }
+        }
+    }
+}
+
 void get_cleaned_neighbours(float* data, int num_particles, CleanParams* params, int* offsets, int* neighbours_out) {
     g_processor.get_cleaned_neighbours(data, num_particles, params, offsets, neighbours_out);
 }
@@ -303,4 +433,9 @@ void get_cleaned_neighbours(float* data, int num_particles, CleanParams* params,
 // Function to reset the processor state (useful for testing)
 void reset_particles() {
     g_processor.reset();
+}
+
+// Access processed particles
+const std::vector<Particle>& get_processed_particles() {
+    return g_processor.get_particles();
 }

--- a/magpiem/cpp/processing.hpp
+++ b/magpiem/cpp/processing.hpp
@@ -189,7 +189,7 @@ void get_cleaned_neighbours(float* data, int num_points, CleanParams* params, in
 // Combined cleaning and flip detection: returns lattice assignments and flipped particle flags
 void clean_and_detect_flips(float* data, int num_points, CleanParams* params, int* lattice_results, int* flipped_results);
 // Debug function for testing flip detection with manual lattice assignment
-void debug_flip_detection(float* data, int num_points, CleanParams* params, int* lattice_results, int* flipped_results);
+void debug_flip_detection(float* data, int num_points, CleanParams* params, int* lattice_results, int* flipped_results) noexcept(false);
 
 // Function to get access to processed particles (for flip detection)
 const std::vector<Particle>& get_processed_particles();

--- a/magpiem/cpp/processing.hpp
+++ b/magpiem/cpp/processing.hpp
@@ -147,8 +147,8 @@ struct Particle {
         return dot_product(displacement.data(), p.orientation);
     }
 
-    int get_neighbour_count() const {
-        return static_cast<int>(neighbours.size());
+    unsigned int get_neighbour_count() const {
+        return static_cast<unsigned int>(neighbours.size());
     }
 
     Particle* get_neighbour(int index) const {
@@ -186,6 +186,14 @@ void assign_lattices(float* data, int num_points, unsigned int min_neighbours, u
 // return neighbour lists in CSR form. Offsets has length num_points + 1. If
 // neighbours_out is nullptr, only offsets are filled (offsets[num_points] will be total entries).
 void get_cleaned_neighbours(float* data, int num_points, CleanParams* params, int* offsets, int* neighbours_out);
+// Combined cleaning and flip detection: returns lattice assignments and flipped particle flags
+void clean_and_detect_flips(float* data, int num_points, CleanParams* params, int* lattice_results, int* flipped_results);
+// Debug function for testing flip detection with manual lattice assignment
+void debug_flip_detection(float* data, int num_points, CleanParams* params, int* lattice_results, int* flipped_results);
+
+// Function to get access to processed particles (for flip detection)
+const std::vector<Particle>& get_processed_particles();
+
 void set_log_level(int level);
 #ifdef __cplusplus
 }

--- a/magpiem/cpp/processing.hpp
+++ b/magpiem/cpp/processing.hpp
@@ -20,15 +20,18 @@ struct CleanParams {
     float max_curvature;
     unsigned int min_lattice_size;
     unsigned int min_neighbours;
+    bool allow_flips;
     
     CleanParams(float min_dist, float max_dist,
                 float min_ori, float max_ori,
                 float min_curv, float max_curv,
-                unsigned int min_lattice_size = 10, unsigned int min_neigh = 3)
+                unsigned int min_lattice_size = 10, unsigned int min_neigh = 3,
+                bool allow_flips = false)
         : min_distance(min_dist), max_distance(max_dist),
           min_orientation(min_ori), max_orientation(max_ori),
           min_curvature(min_curv), max_curvature(max_curv),
-          min_lattice_size(min_lattice_size), min_neighbours(min_neigh) {}
+          min_lattice_size(min_lattice_size), min_neighbours(min_neigh),
+          allow_flips(allow_flips) {}
 };
 
 struct Particle {
@@ -176,7 +179,7 @@ extern "C" {
 #endif
 void clean_particles(float* data, int num_points, CleanParams* params, int* results);
 void find_neighbours(float* data, int num_points, float min_distance, float max_distance, int* results);
-void filter_by_orientation(float* data, int num_points, float min_orientation, float max_orientation, int* results);
+void filter_by_orientation(float* data, int num_points, float min_orientation, float max_orientation, bool allow_flips, int* results);
 void filter_by_curvature(float* data, int num_points, float min_curvature, float max_curvature, int* results);
 void assign_lattices(float* data, int num_points, unsigned int min_neighbours, unsigned int min_lattice_size, int* results);
 // Debug/testing utility: perform distance + orientation + curvature filtering and

--- a/magpiem/cpp/processing_extension.cpp
+++ b/magpiem/cpp/processing_extension.cpp
@@ -165,7 +165,8 @@ static PyObject* py_clean_particles(PyObject* self, PyObject* args) {
         (float)PyFloat_AsDouble(PyList_GetItem(params_obj, 4)), // min_curvature
         (float)PyFloat_AsDouble(PyList_GetItem(params_obj, 5)), // max_curvature
         (unsigned int)PyLong_AsLong(PyList_GetItem(params_obj, 6)), // min_lattice_size
-        (unsigned int)PyLong_AsLong(PyList_GetItem(params_obj, 7))  // min_neighbours
+        (unsigned int)PyLong_AsLong(PyList_GetItem(params_obj, 7)), // min_neighbours
+        (bool)PyLong_AsLong(PyList_GetItem(params_obj, 8))  // allow_flips
     );
     
     int* results = new int[num_particles];
@@ -183,6 +184,17 @@ static PyObject* py_clean_particles(PyObject* self, PyObject* args) {
     return results_list;
 }
 
+static PyObject* py_set_log_level(PyObject* self, PyObject* args) {
+    int level;
+    
+    if (!PyArg_ParseTuple(args, "i", &level)) {
+        return NULL;
+    }
+    
+    set_log_level(level);
+    Py_RETURN_NONE;
+}
+
 // Method definitions
 static PyMethodDef processing_methods[] = {
     {"find_neighbours", py_find_neighbours, METH_VARARGS, "Find neighbours based on distance"},
@@ -190,6 +202,7 @@ static PyMethodDef processing_methods[] = {
     {"filter_by_curvature", py_filter_by_curvature, METH_VARARGS, "Filter neighbours by curvature"},
     {"assign_lattices", py_assign_lattices, METH_VARARGS, "Assign particles to lattices"},
     {"clean_particles", py_clean_particles, METH_VARARGS, "Run full particle cleaning pipeline"},
+    {"set_log_level", py_set_log_level, METH_VARARGS, "Set C++ log level"},
     {NULL, NULL, 0, NULL} // Sentinel
 };
 

--- a/magpiem/cpp/processing_extension.cpp
+++ b/magpiem/cpp/processing_extension.cpp
@@ -184,6 +184,112 @@ static PyObject* py_clean_particles(PyObject* self, PyObject* args) {
     return results_list;
 }
 
+static PyObject* py_clean_and_detect_flips(PyObject* self, PyObject* args) {
+    PyObject* data_obj;
+    int num_particles;
+    PyObject* params_obj;
+    
+    if (!PyArg_ParseTuple(args, "OiO", &data_obj, &num_particles, &params_obj)) {
+        return NULL;
+    }
+    
+    float* data = new float[num_particles * 6];
+    for (int i = 0; i < num_particles * 6; i++) {
+        PyObject* item = PyList_GetItem(data_obj, i);
+        data[i] = (float)PyFloat_AsDouble(item);
+    }
+    
+    // Extract parameters from Python object
+    CleanParams params(
+        (float)PyFloat_AsDouble(PyList_GetItem(params_obj, 0)), // min_distance
+        (float)PyFloat_AsDouble(PyList_GetItem(params_obj, 1)), // max_distance
+        (float)PyFloat_AsDouble(PyList_GetItem(params_obj, 2)), // min_orientation
+        (float)PyFloat_AsDouble(PyList_GetItem(params_obj, 3)), // max_orientation
+        (float)PyFloat_AsDouble(PyList_GetItem(params_obj, 4)), // min_curvature
+        (float)PyFloat_AsDouble(PyList_GetItem(params_obj, 5)), // max_curvature
+        (unsigned int)PyLong_AsLong(PyList_GetItem(params_obj, 6)), // min_lattice_size
+        (unsigned int)PyLong_AsLong(PyList_GetItem(params_obj, 7)), // min_neighbours
+        (bool)PyLong_AsLong(PyList_GetItem(params_obj, 8))  // allow_flips
+    );
+    
+    int* lattice_results = new int[num_particles];
+    int* flipped_results = new int[num_particles];
+    
+    clean_and_detect_flips(data, num_particles, &params, lattice_results, flipped_results);
+    
+    // Convert results back to Python - return tuple of (lattice_results, flipped_results)
+    PyObject* lattice_list = PyList_New(num_particles);
+    PyObject* flipped_list = PyList_New(num_particles);
+    
+    for (int i = 0; i < num_particles; i++) {
+        PyList_SetItem(lattice_list, i, PyLong_FromLong(lattice_results[i]));
+        PyList_SetItem(flipped_list, i, PyLong_FromLong(flipped_results[i]));
+    }
+    
+    PyObject* result_tuple = PyTuple_New(2);
+    PyTuple_SetItem(result_tuple, 0, lattice_list);
+    PyTuple_SetItem(result_tuple, 1, flipped_list);
+    
+    delete[] data;
+    delete[] lattice_results;
+    delete[] flipped_results;
+    
+    return result_tuple;
+}
+
+static PyObject* py_debug_flip_detection(PyObject* self, PyObject* args) {
+    PyObject* data_obj;
+    int num_particles;
+    PyObject* params_obj;
+    
+    if (!PyArg_ParseTuple(args, "OiO", &data_obj, &num_particles, &params_obj)) {
+        return NULL;
+    }
+    
+    float* data = new float[num_particles * 6];
+    for (int i = 0; i < num_particles * 6; i++) {
+        PyObject* item = PyList_GetItem(data_obj, i);
+        data[i] = (float)PyFloat_AsDouble(item);
+    }
+    
+    // Extract parameters from Python object
+    CleanParams params(
+        (float)PyFloat_AsDouble(PyList_GetItem(params_obj, 0)), // min_distance
+        (float)PyFloat_AsDouble(PyList_GetItem(params_obj, 1)), // max_distance
+        (float)PyFloat_AsDouble(PyList_GetItem(params_obj, 2)), // min_orientation
+        (float)PyFloat_AsDouble(PyList_GetItem(params_obj, 3)), // max_orientation
+        (float)PyFloat_AsDouble(PyList_GetItem(params_obj, 4)), // min_curvature
+        (float)PyFloat_AsDouble(PyList_GetItem(params_obj, 5)), // max_curvature
+        (unsigned int)PyLong_AsLong(PyList_GetItem(params_obj, 6)), // min_lattice_size
+        (unsigned int)PyLong_AsLong(PyList_GetItem(params_obj, 7)), // min_neighbours
+        (bool)PyLong_AsLong(PyList_GetItem(params_obj, 8))  // allow_flips
+    );
+    
+    int* lattice_results = new int[num_particles];
+    int* flipped_results = new int[num_particles];
+    
+    debug_flip_detection(data, num_particles, &params, lattice_results, flipped_results);
+    
+    // Convert results back to Python - return tuple of (lattice_results, flipped_results)
+    PyObject* lattice_list = PyList_New(num_particles);
+    PyObject* flipped_list = PyList_New(num_particles);
+    
+    for (int i = 0; i < num_particles; i++) {
+        PyList_SetItem(lattice_list, i, PyLong_FromLong(lattice_results[i]));
+        PyList_SetItem(flipped_list, i, PyLong_FromLong(flipped_results[i]));
+    }
+    
+    PyObject* result_tuple = PyTuple_New(2);
+    PyTuple_SetItem(result_tuple, 0, lattice_list);
+    PyTuple_SetItem(result_tuple, 1, flipped_list);
+    
+    delete[] data;
+    delete[] lattice_results;
+    delete[] flipped_results;
+    
+    return result_tuple;
+}
+
 static PyObject* py_set_log_level(PyObject* self, PyObject* args) {
     int level;
     
@@ -202,6 +308,8 @@ static PyMethodDef processing_methods[] = {
     {"filter_by_curvature", py_filter_by_curvature, METH_VARARGS, "Filter neighbours by curvature"},
     {"assign_lattices", py_assign_lattices, METH_VARARGS, "Assign particles to lattices"},
     {"clean_particles", py_clean_particles, METH_VARARGS, "Run full particle cleaning pipeline"},
+    {"clean_and_detect_flips", py_clean_and_detect_flips, METH_VARARGS, "Run cleaning and flip detection pipeline"},
+    {"debug_flip_detection", py_debug_flip_detection, METH_VARARGS, "Debug flip detection with manual lattice assignment"},
     {"set_log_level", py_set_log_level, METH_VARARGS, "Set C++ log level"},
     {NULL, NULL, 0, NULL} // Sentinel
 };

--- a/magpiem/cpp/processing_extension.cpp
+++ b/magpiem/cpp/processing_extension.cpp
@@ -52,10 +52,13 @@ static PyObject* py_filter_by_orientation(PyObject* self, PyObject* args) {
     PyObject* data_obj;
     int num_particles;
     float min_orientation, max_orientation;
+    int allow_flips_int = 0;
     
-    if (!PyArg_ParseTuple(args, "Oiff", &data_obj, &num_particles, &min_orientation, &max_orientation)) {
+    if (!PyArg_ParseTuple(args, "Oiff|i", &data_obj, &num_particles, &min_orientation, &max_orientation, &allow_flips_int)) {
         return NULL;
     }
+    
+    bool allow_flips = (allow_flips_int != 0);
     
     float* data = new float[num_particles * 6];
     for (int i = 0; i < num_particles * 6; i++) {
@@ -65,7 +68,7 @@ static PyObject* py_filter_by_orientation(PyObject* self, PyObject* args) {
     
     int* results = new int[num_particles];
     
-    filter_by_orientation(data, num_particles, min_orientation, max_orientation, results);
+    filter_by_orientation(data, num_particles, min_orientation, max_orientation, allow_flips, results);
     
     PyObject* results_list = PyList_New(num_particles);
     for (int i = 0; i < num_particles; i++) {

--- a/magpiem/cpp/processing_wrapper.cpp
+++ b/magpiem/cpp/processing_wrapper.cpp
@@ -26,7 +26,7 @@ PyMODINIT_FUNC PyInit_processing_cpp(void) {
 extern "C" {
     void clean_particles(float* data, int num_points, CleanParams* params, int* results);
     void find_neighbours(float* data, int num_points, float min_distance, float max_distance, int* results);
-    void filter_by_orientation(float* data, int num_points, float min_orientation, float max_orientation, int* results);
+    void filter_by_orientation(float* data, int num_points, float min_orientation, float max_orientation, bool allow_flips, int* results);
     void filter_by_curvature(float* data, int num_points, float min_curvature, float max_curvature, int* results);
     void assign_lattices(float* data, int num_points, unsigned int min_neighbours, unsigned int min_lattice_size, int* results);
     void get_cleaned_neighbours(float* data, int num_points, CleanParams* params, int* offsets, int* neighbours_out);

--- a/magpiem/dash/layout.py
+++ b/magpiem/dash/layout.py
@@ -357,6 +357,7 @@ def create_store_components():
             dcc.Store(id="store-session-key", data=""),
             dcc.Store(id="store-cache-cleared", data=0),
             dcc.Store(id="store-cleaning-progress", data=0),
+            dcc.Store(id="store-flips"),
         ]
     )
 

--- a/magpiem/dash/layout.py
+++ b/magpiem/dash/layout.py
@@ -236,17 +236,31 @@ def create_save_table():
     return html.Table(
         [
             html.Tr(
+                [
+                    html.Th("", style={"width": "70%"}),
+                    html.Th("", style={"width": "30%"}),
+                ]
+            ),
+            html.Tr(
                 html.Td(dbc.Button("Save Current Progress", id="button-save-progress"))
             ),
             html.Tr(
                 [
                     html.Td("Keep selected particles", id="label-keep-particles"),
-                    daq.BooleanSwitch(id="switch-keep-particles", on=True),
+                    html.Td(daq.BooleanSwitch(id="switch-keep-particles", on=True)),
                 ]
             ),
             html.Tr(
                 [
-                    html.Td("Save as:"),
+                    html.Td("Rotate flipped particles?", id="label-flip-particles"),
+                    html.Td(daq.BooleanSwitch(id="switch-flip-particles", on=False)),
+                ],
+                style={"visibility": "hidden"},
+                id="div-flip-particles",
+            ),
+            html.Tr(
+                [
+                    html.Td("Save as:", style={"vertical-align": "middle"}),
                     html.Td(
                         dbc.Input(id="input-save-filename", style={"width": "100px"})
                     ),
@@ -264,7 +278,12 @@ def create_save_table():
             html.Tr(html.Td(dbc.Button("Save Particles", id="button-save"))),
             dcc.Download(id="download-file"),
         ],
-        style={"overflow": "hidden", "margin": "3px", "width": "100%"},
+        style={
+            "overflow": "hidden",
+            "margin": "3px",
+            "width": "100%",
+            "table-layout": "fixed",
+        },
     )
 
 

--- a/magpiem/dash/ui_callbacks.py
+++ b/magpiem/dash/ui_callbacks.py
@@ -55,6 +55,17 @@ def register_ui_callbacks(app, temp_file_dir):
             return cleaning_phase
 
     @app.callback(
+        Output("div-flip-particles", "style"),
+        Input("switch-allow-flips", "on"),
+        prevent_initial_call=True,
+    )
+    def update_flipping_switch(flipping_enabled):
+        if flipping_enabled:
+            return {"visibility": "visible"}
+        else:
+            return {"visibility": "hidden"}
+
+    @app.callback(
         Output("dropdown-tomo", "options"),
         Output("dropdown-tomo", "value"),
         Output("store-clicked-point", "data"),

--- a/magpiem/io/README_emC_format.txt
+++ b/magpiem/io/README_emC_format.txt
@@ -1,0 +1,11 @@
+Template-matching geometries are stored in [subTomoMeta][cycle000][geometry] in an array with 26 columns.
+Several of these columns are simply empty or default values (according to the emC tutorial)
+0: CC index
+1: Tmp_sampling (current binning of image)
+2: empty
+3: Unique particle ID
+4-9: empty
+10-12: x, y, z coordinates describing centre of particle
+13-15: ϕ, θ, ψ euler angles describing particle orientation in intrinsic z-x-z convention. Not actually used by emClarity
+16-24: 3D Rotation matrix describing particle orientation. Ordered 11, 21, 31, 12, 22, 32, 13, 23, 33
+25: Particle classification. Should be 1 at this stage.

--- a/magpiem/plotting/plot_cache.py
+++ b/magpiem/plotting/plot_cache.py
@@ -134,6 +134,7 @@ def get_cached_tomogram_figure(
     lattice_data: dict,
     cone_size: float = -1,
     show_removed: bool = False,
+    flipped_particle_indices: list = None,
 ) -> go.Figure | None:
     """
     Get tomogram figure from cache or create it if not cached.
@@ -193,6 +194,7 @@ def get_cached_tomogram_figure(
         figure = create_particle_plot_from_raw_data(
             raw_data,
             cone_size=cone_size,
+            flipped_particle_indices=flipped_particle_indices,
         )
     else:
         figure = create_lattice_plot_from_raw_data(
@@ -201,6 +203,7 @@ def get_cached_tomogram_figure(
             cone_size=cone_size,
             show_removed_particles=show_removed,
             selected_lattices=None,
+            flipped_particle_indices=flipped_particle_indices,
         )
 
     log.debug("Created new figure, adding to cache")
@@ -218,6 +221,7 @@ def preload_tomograms(
     lattice_data: dict,
     cone_size: float = -1,
     show_removed: bool = False,
+    flip_data: dict = None,
 ) -> None:
     """
     Pre-load the current and next few tomogram figures that the user is likely to view.
@@ -257,6 +261,11 @@ def preload_tomograms(
         )
         if cached_figure is None:
             try:
+                # Get flipped particle indices for this tomogram
+                flipped_particle_indices = (
+                    flip_data.get(next_tomo_name, []) if flip_data else []
+                )
+
                 figure = get_cached_tomogram_figure(
                     next_tomo_name,
                     data_path,
@@ -264,6 +273,7 @@ def preload_tomograms(
                     lattice_data,
                     cone_size,
                     show_removed,
+                    flipped_particle_indices,
                 )
 
             except Exception as e:

--- a/magpiem/plotting/plotting_callbacks.py
+++ b/magpiem/plotting/plotting_callbacks.py
@@ -98,6 +98,8 @@ def register_plotting_callbacks(app, cache_functions, temp_file_dir):
         try:
             data_path = tomogram_raw_data["__data_path__"]
             logger.debug("Preloading tomograms with new style")
+            # Only pass flip_data if flip_particles is enabled
+            effective_flip_data = flip_data if flip_particles else None
             preload_tomograms(
                 selected_tomo_name,
                 tomogram_raw_data["__tomogram_names__"],
@@ -106,7 +108,7 @@ def register_plotting_callbacks(app, cache_functions, temp_file_dir):
                 lattice_data,
                 cone_size,
                 show_removed,
-                flip_data,
+                effective_flip_data,
             )
         except Exception as e:
             logger.debug("Failed to update cache: %s", e)
@@ -152,6 +154,8 @@ def register_plotting_callbacks(app, cache_functions, temp_file_dir):
         logger.debug("make_cones=%s, cone_size=%s", make_cones, cone_size)
         logger.debug("cache_cleared=%s", cache_cleared)
 
+        # Only pass flip_data if flip_particles is enabled
+        effective_flip_data = flip_data if flip_particles else None
         fig = get_tomogram_figure(
             selected_tomo_name,
             tomogram_raw_data,
@@ -160,7 +164,7 @@ def register_plotting_callbacks(app, cache_functions, temp_file_dir):
             make_cones,
             cone_size,
             show_removed,
-            flip_data,
+            effective_flip_data,
             get_cached_tomogram_figure,
             EMPTY_FIG,
         )
@@ -311,6 +315,8 @@ def register_plotting_callbacks(app, cache_functions, temp_file_dir):
 
         try:
             data_path = tomogram_raw_data["__data_path__"]
+            # Only pass flip_data if flip_particles is enabled
+            effective_flip_data = flip_data if flip_particles else None
             preload_tomograms(
                 selected_tomo_name,
                 tomogram_raw_data["__tomogram_names__"],
@@ -319,7 +325,7 @@ def register_plotting_callbacks(app, cache_functions, temp_file_dir):
                 lattice_data,
                 cone_size,
                 show_removed,
-                flip_data,
+                effective_flip_data,
             )
         except Exception as e:
             logger.warning(f"Failed to update cache with new lattice data: {e}")

--- a/magpiem/plotting/plotting_callbacks.py
+++ b/magpiem/plotting/plotting_callbacks.py
@@ -52,11 +52,13 @@ def register_plotting_callbacks(app, cache_functions, temp_file_dir):
         Input("inp-cone-size", "value"),
         Input("button-set-cone-size", "n_clicks"),
         Input("switch-show-removed", "on"),
+        Input("switch-flip-particles", "on"),
         State("store-session-key", "data"),
         State("store-tomogram-data", "data"),
         State("store-lattice-data", "data"),
         State("store-selected-lattices", "data"),
         State("dropdown-tomo", "value"),
+        State("store-flips", "data"),
         prevent_initial_call=True,
     )
     def handle_plot_style_changes(
@@ -64,19 +66,22 @@ def register_plotting_callbacks(app, cache_functions, temp_file_dir):
         cone_size,
         cone_clicks,
         show_removed,
+        flip_particles,
         session_key,
         tomogram_raw_data,
         lattice_data,
         selected_lattices,
         selected_tomo_name,
+        flip_data,
     ):
         """Handle plot style changes and update cache accordingly."""
         logger.debug("handle_plot_style_changes called")
         logger.debug(
-            "make_cones=%s, cone_size=%s, show_removed=%s",
+            "make_cones=%s, cone_size=%s, show_removed=%s, flip_particles=%s",
             make_cones,
             cone_size,
             show_removed,
+            flip_particles,
         )
 
         if not session_key or not tomogram_raw_data or not selected_tomo_name:
@@ -101,6 +106,7 @@ def register_plotting_callbacks(app, cache_functions, temp_file_dir):
                 lattice_data,
                 cone_size,
                 show_removed,
+                flip_data,
             )
         except Exception as e:
             logger.debug("Failed to update cache: %s", e)
@@ -122,6 +128,8 @@ def register_plotting_callbacks(app, cache_functions, temp_file_dir):
         State("switch-cone-plot", "on"),
         State("inp-cone-size", "value"),
         State("switch-show-removed", "on"),
+        State("switch-flip-particles", "on"),
+        State("store-flips", "data"),
         prevent_initial_call=True,
     )
     def plot_tomo(
@@ -136,6 +144,8 @@ def register_plotting_callbacks(app, cache_functions, temp_file_dir):
         make_cones,
         cone_size,
         show_removed,
+        flip_particles,
+        flip_data,
     ):
         """Retrieve and plot cached tomo"""
         logger.debug("plot_tomo called with selected_tomo_name=%s", selected_tomo_name)
@@ -150,6 +160,7 @@ def register_plotting_callbacks(app, cache_functions, temp_file_dir):
             make_cones,
             cone_size,
             show_removed,
+            flip_data,
             get_cached_tomogram_figure,
             EMPTY_FIG,
         )
@@ -272,6 +283,8 @@ def register_plotting_callbacks(app, cache_functions, temp_file_dir):
         State("switch-cone-plot", "on"),
         State("inp-cone-size", "value"),
         State("switch-show-removed", "on"),
+        State("switch-flip-particles", "on"),
+        State("store-flips", "data"),
         prevent_initial_call=True,
     )
     def handle_lattice_data_cache_update(
@@ -283,6 +296,8 @@ def register_plotting_callbacks(app, cache_functions, temp_file_dir):
         make_cones,
         cone_size,
         show_removed,
+        flip_particles,
+        flip_data,
     ):
         """Update cache when lattice data is produced via cleaning"""
         if not session_key or not tomogram_raw_data or not selected_tomo_name:
@@ -304,6 +319,7 @@ def register_plotting_callbacks(app, cache_functions, temp_file_dir):
                 lattice_data,
                 cone_size,
                 show_removed,
+                flip_data,
             )
         except Exception as e:
             logger.warning(f"Failed to update cache with new lattice data: {e}")

--- a/magpiem/processing/classes/cleaner.py
+++ b/magpiem/processing/classes/cleaner.py
@@ -20,6 +20,7 @@ class Cleaner:
     dist_range: tuple
     ori_range: tuple
     curv_range: tuple
+    allow_flips: bool
     flipped_ori_range: tuple
 
     def __init__(
@@ -30,6 +31,7 @@ class Cleaner:
         dist_range: tuple[float],
         ori_range: tuple[float],
         curv_range: tuple[float],
+        allow_flips: bool,
         flipped_ori_range: tuple[float] | None,
     ):
         self.cc_threshold = cc_thresh
@@ -38,6 +40,7 @@ class Cleaner:
         self.dist_range = dist_range
         self.ori_range = ori_range
         self.curv_range = curv_range
+        self.allow_flips = allow_flips
         self.flipped_ori_range = flipped_ori_range
         logger.debug(f"Cleaner initialized: {self}")
 
@@ -68,6 +71,7 @@ class Cleaner:
             dist_range,
             ori_range,
             curv_range,
+            allow_flips,
             flipped_ori_range,
         )
 

--- a/magpiem/processing/classes/particle.py
+++ b/magpiem/processing/classes/particle.py
@@ -281,6 +281,23 @@ class Particle:
     def get_neighbour_array(self, prop: str) -> np.ndarray:
         return Particle.get_property_array(self.neighbours, prop)
 
+    def find_flipped_neighbours(self) -> None:
+        """
+        Recursively assign all neighbours a direction based on their relative orientation
+        to the lattice as a whole.
+        Requires all neighbours to have been assigned.
+
+        Result will be stored in each particle's "direction" attribute
+        """
+        for neighbour in self.neighbours:
+            if hasattr(neighbour, "direction") and neighbour.direction is not None:
+                continue
+            if self.dot_orientation(neighbour) in self.tomo.cleaning_params.ori_range:
+                neighbour.direction = self.direction
+            else:
+                neighbour.direction = -self.direction
+            neighbour.find_flipped_neighbours()
+
     def to_dict(self) -> dict:
         """
         Serialise for JSON conversion

--- a/magpiem/processing/classes/particle.py
+++ b/magpiem/processing/classes/particle.py
@@ -292,7 +292,9 @@ class Particle:
         for neighbour in self.neighbours:
             if hasattr(neighbour, "direction") and neighbour.direction is not None:
                 continue
-            if self.dot_orientation(neighbour) in self.tomo.cleaning_params.ori_range:
+            if within(
+                self.dot_orientation(neighbour), self.tomo.cleaning_params.ori_range
+            ):
                 neighbour.direction = self.direction
             else:
                 neighbour.direction = -self.direction

--- a/magpiem/processing/cpp_integration.py
+++ b/magpiem/processing/cpp_integration.py
@@ -108,7 +108,9 @@ def invert_lattice_assignments(results: dict) -> dict:
     return lattice_assignments
 
 
-def clean_and_detect_flips_with_cpp(tomogram_raw_data: list, clean_params: Cleaner) -> tuple[dict, list]:
+def clean_and_detect_flips_with_cpp(
+    tomogram_raw_data: list, clean_params: Cleaner
+) -> tuple[dict, list]:
     """
     Clean tomogram data and detect flipped particles using the C++ library, with fallback to python
 
@@ -133,7 +135,9 @@ def clean_and_detect_flips_with_cpp(tomogram_raw_data: list, clean_params: Clean
     except ImportError as e:
         logger.warning(f"C++ library not available: {e}")
         logger.info("Falling back to Python implementation using Tomogram class")
-        return _clean_and_detect_flips_with_python_fallback(tomogram_raw_data, clean_params)
+        return _clean_and_detect_flips_with_python_fallback(
+            tomogram_raw_data, clean_params
+        )
 
 
 def clean_tomo_with_cpp(tomogram_raw_data: list, clean_params: Cleaner) -> dict:
@@ -164,7 +168,9 @@ def clean_tomo_with_cpp(tomogram_raw_data: list, clean_params: Cleaner) -> dict:
         return _clean_with_python_fallback(tomogram_raw_data, clean_params)
 
 
-def _clean_and_detect_flips_with_cpp(tomogram_raw_data: list, clean_params: Cleaner) -> tuple[dict, list]:
+def _clean_and_detect_flips_with_cpp(
+    tomogram_raw_data: list, clean_params: Cleaner
+) -> tuple[dict, list]:
     """Clean and detect flips using C++ library implementation."""
     logger.debug(f"Python wrapper called with {len(tomogram_raw_data)} particles")
     flat_data, num_particles = convert_raw_data_to_cpp_format(tomogram_raw_data)
@@ -190,8 +196,12 @@ def _clean_and_detect_flips_with_cpp(tomogram_raw_data: list, clean_params: Clea
     c_lib = setup_cpp_library()
     logger.debug("Calling C++ clean_and_detect_flips function")
 
-    lattice_results, flipped_results = c_lib.clean_and_detect_flips(flat_data, num_particles, params_list)
-    logger.debug(f"C++ returned {len(flipped_results)} results, {sum(flipped_results)} flipped")
+    lattice_results, flipped_results = c_lib.clean_and_detect_flips(
+        flat_data, num_particles, params_list
+    )
+    logger.debug(
+        f"C++ returned {len(flipped_results)} results, {sum(flipped_results)} flipped"
+    )
     logger.debug(f"Lattice results: {lattice_results}")
     logger.debug(f"Flipped results: {flipped_results}")
 
@@ -199,15 +209,19 @@ def _clean_and_detect_flips_with_cpp(tomogram_raw_data: list, clean_params: Clea
     lattice_assignments = invert_lattice_assignments(lattice_results)
 
     # Convert flipped results to list of particle indices
-    flipped_particles = [i for i, is_flipped in enumerate(flipped_results) if is_flipped]
+    flipped_particles = [
+        i for i, is_flipped in enumerate(flipped_results) if is_flipped
+    ]
 
     return lattice_assignments, flipped_particles
 
 
-def debug_flip_detection_with_cpp(tomogram_raw_data: list, clean_params: Cleaner) -> tuple[dict, list]:
+def debug_flip_detection_with_cpp(
+    tomogram_raw_data: list, clean_params: Cleaner
+) -> tuple[dict, list]:
     """
     Debug flip detection using C++ library with manual lattice assignment.
-    
+
     Parameters
     ----------
     tomogram_raw_data : list
@@ -228,10 +242,14 @@ def debug_flip_detection_with_cpp(tomogram_raw_data: list, clean_params: Cleaner
     except ImportError as e:
         logger.error(f"C++ library not available: {e}")
         logger.info("Falling back to Python implementation using Tomogram class")
-        return _clean_and_detect_flips_with_python_fallback(tomogram_raw_data, clean_params)
+        return _clean_and_detect_flips_with_python_fallback(
+            tomogram_raw_data, clean_params
+        )
 
 
-def _debug_flip_detection_with_cpp(tomogram_raw_data: list, clean_params: Cleaner) -> tuple[dict, list]:
+def _debug_flip_detection_with_cpp(
+    tomogram_raw_data: list, clean_params: Cleaner
+) -> tuple[dict, list]:
     """Debug flip detection using C++ library implementation."""
     flat_data, num_particles = convert_raw_data_to_cpp_format(tomogram_raw_data)
 
@@ -253,18 +271,24 @@ def _debug_flip_detection_with_cpp(tomogram_raw_data: list, clean_params: Cleane
 
     c_lib = setup_cpp_library()
 
-    lattice_results, flipped_results = c_lib.debug_flip_detection(flat_data, num_particles, params_list)
+    lattice_results, flipped_results = c_lib.debug_flip_detection(
+        flat_data, num_particles, params_list
+    )
 
     # Convert lattice results to dictionary format
     lattice_assignments = invert_lattice_assignments(lattice_results)
 
     # Convert flipped results to list of particle indices
-    flipped_particles = [i for i, is_flipped in enumerate(flipped_results) if is_flipped]
+    flipped_particles = [
+        i for i, is_flipped in enumerate(flipped_results) if is_flipped
+    ]
 
     return lattice_assignments, flipped_particles
 
 
-def _clean_and_detect_flips_with_python_fallback(tomogram_raw_data: list, clean_params: Cleaner) -> tuple[dict, list]:
+def _clean_and_detect_flips_with_python_fallback(
+    tomogram_raw_data: list, clean_params: Cleaner
+) -> tuple[dict, list]:
     """Fallback to Python implementation for cleaning and flip detection."""
     # Create a temporary tomogram for processing
     temp_tomo = Tomogram("temp")
@@ -273,7 +297,7 @@ def _clean_and_detect_flips_with_python_fallback(tomogram_raw_data: list, clean_
 
     lattice_data = temp_tomo.autoclean()
     flipped_particles = temp_tomo.find_flipped_particles()
-    
+
     # Convert flipped particles to indices
     flipped_indices = [p.particle_id for p in flipped_particles]
 

--- a/magpiem/processing/cpp_integration.py
+++ b/magpiem/processing/cpp_integration.py
@@ -153,6 +153,7 @@ def _clean_with_cpp(tomogram_raw_data: list, clean_params: Cleaner) -> dict:
         clean_params.curv_range[1],  # max_curvature
         clean_params.min_lattice_size,
         clean_params.min_neighbours,
+        clean_params.allow_flips,
     ]
 
     c_lib = setup_cpp_library()

--- a/magpiem/processing/processing_utils.py
+++ b/magpiem/processing/processing_utils.py
@@ -20,6 +20,7 @@ def process_single_tomogram(
     clean_total_time,
     read_emc_tomogram_raw_data,
     clean_tomo_with_cpp,
+    clean_and_detect_flips_with_cpp=None,
 ):
     """Process a single tomogram and return lattice data and timing info."""
     t0 = time()
@@ -27,14 +28,23 @@ def process_single_tomogram(
 
     if tomo_name not in full_geom:
         logger.warning(f"Tomogram {tomo_name} not found in .mat file")
-        return None, 0
+        return None, 0, None
 
     tomo_raw_data = read_emc_tomogram_raw_data(full_geom[tomo_name], tomo_name)
     if tomo_raw_data is None:
         logger.warning(f"Failed to extract data for tomogram: {tomo_name}")
-        return None, 0
+        return None, 0, None
 
-    lattice_data = clean_tomo_with_cpp(tomo_raw_data, clean_params)
+    # Use flip detection if allow_flips is True and function is provided
+    if clean_params.allow_flips and clean_and_detect_flips_with_cpp is not None:
+        lattice_data, flipped_particles = clean_and_detect_flips_with_cpp(
+            tomo_raw_data, clean_params
+        )
+        flip_data = {tomo_name: flipped_particles}
+    else:
+        lattice_data = clean_tomo_with_cpp(tomo_raw_data, clean_params)
+        flip_data = None
+
     processing_time = time() - t0
 
     progress_percent = int((clean_count / total_tomos) * 100)
@@ -52,4 +62,4 @@ def process_single_tomogram(
             f"Progress: {clean_count}/{total_tomos} ({progress_percent}%) - Time remaining: {formatted_time_remaining}"
         )
 
-    return lattice_data, processing_time
+    return lattice_data, processing_time, flip_data

--- a/test/data/create_filtered_dataset.py
+++ b/test/data/create_filtered_dataset.py
@@ -23,10 +23,11 @@ TEST_TOMO_NAME = "wt2nd_4004_2"
 FILTER_centre = np.array([828, 545, 732])
 FILTER_RADIUS = 300.0
 
+
 def filter_particles_by_position(tomogram_raw_data, centre, radius):
     """
     Filter particles to only include those within radius of centre position.
-    
+
     Parameters
     ----------
     tomogram_raw_data : list
@@ -35,7 +36,7 @@ def filter_particles_by_position(tomogram_raw_data, centre, radius):
         centre position [x, y, z]
     radius : float
         Maximum distance from centre
-        
+
     Returns
     -------
     tuple
@@ -43,71 +44,77 @@ def filter_particles_by_position(tomogram_raw_data, centre, radius):
     """
     filtered_data = []
     filtered_indices = []
-    
+
     for i, particle in enumerate(tomogram_raw_data):
         position = np.array(particle[0])  # [x, y, z]
         distance = np.linalg.norm(position - centre)
-        
+
         if distance <= radius:
             filtered_data.append(particle)
             filtered_indices.append(i)
-    
+
     return filtered_data, filtered_indices
+
 
 def main():
     """Main function to create filtered dataset."""
     print(f"Loading data from {DATA_FILE}")
-    
+
     mat_full = scipy.io.loadmat(str(DATA_FILE), simplify_cells=True, mat_dtype=True)
     mat_geom = mat_full["subTomoMeta"]["cycle000"]["geometry"]
-    
+
     print(f"Loaded geometry data with {len(mat_geom)} tomograms")
-    
+
     if TEST_TOMO_NAME not in mat_geom:
         print(f"Error: Tomogram {TEST_TOMO_NAME} not found in the data")
         return
-    
+
     tomo_raw_data = read_emc_tomogram_raw_data(mat_geom[TEST_TOMO_NAME], TEST_TOMO_NAME)
     if tomo_raw_data is None:
         print(f"Error: Failed to extract data for tomogram: {TEST_TOMO_NAME}")
         return
-    
+
     print(f"Original dataset has {len(tomo_raw_data)} particles")
-    
+
     print(f"Filtering particles within {FILTER_RADIUS} units of {FILTER_centre}")
     filtered_data, filtered_indices = filter_particles_by_position(
         tomo_raw_data, FILTER_centre, FILTER_RADIUS
     )
-    
+
     print(f"Filtered dataset has {len(filtered_data)} particles")
-    print(f"Filtered indices: {filtered_indices[:10]}{'...' if len(filtered_indices) > 10 else ''}")
-    
+    print(
+        f"Filtered indices: {filtered_indices[:10]}{'...' if len(filtered_indices) > 10 else ''}"
+    )
+
     if len(filtered_data) == 0:
         print("Error: No particles found within the specified radius")
         return
-    
+
     original_tomo_data = mat_geom[TEST_TOMO_NAME]
     filtered_tomo_data = []
-    
+
     for idx in filtered_indices:
         filtered_tomo_data.append(original_tomo_data[idx])
-    
+
     new_mat_full = mat_full.copy()
-    new_mat_full["subTomoMeta"]["cycle000"]["geometry"] = {TEST_TOMO_NAME: filtered_tomo_data}
-    
+    new_mat_full["subTomoMeta"]["cycle000"]["geometry"] = {
+        TEST_TOMO_NAME: filtered_tomo_data
+    }
+
     print(f"Saving filtered dataset to {OUTPUT_FILE}")
     scipy.io.savemat(str(OUTPUT_FILE), mdict=new_mat_full)
-    
+
     print(f"✓ Filtered dataset saved successfully!")
     print(f"  - Original particles: {len(tomo_raw_data)}")
     print(f"  - Filtered particles: {len(filtered_data)}")
     print(f"  - Reduction: {(1 - len(filtered_data)/len(tomo_raw_data))*100:.1f}%")
-    
+
     positions = np.array([particle[0] for particle in filtered_data])
     print(f"  - Position range:")
     print(f"    X: {positions[:, 0].min():.1f} to {positions[:, 0].max():.1f}")
     print(f"    Y: {positions[:, 1].min():.1f} to {positions[:, 1].max():.1f}")
     print(f"    Z: {positions[:, 2].min():.1f} to {positions[:, 2].max():.1f}")
+
 
 if __name__ == "__main__":
     main()

--- a/test/data/create_filtered_dataset.py
+++ b/test/data/create_filtered_dataset.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Temporary script to create a filtered dataset for testing
+
+Creates a new mat file with the filtered data.
+"""
+
+import sys
+import numpy as np
+from pathlib import Path
+
+# Add project root to path
+project_root = Path(__file__).parent
+sys.path.insert(0, str(project_root))
+
+from magpiem.io.io_utils import read_emc_mat, read_emc_tomogram_raw_data
+import scipy.io
+
+# Configuration
+DATA_FILE = project_root / "test" / "data" / "test_data.mat"
+OUTPUT_FILE = project_root / "test" / "data" / "test_data_filtered.mat"
+TEST_TOMO_NAME = "wt2nd_4004_2"
+FILTER_centre = np.array([828, 545, 732])
+FILTER_RADIUS = 300.0
+
+def filter_particles_by_position(tomogram_raw_data, centre, radius):
+    """
+    Filter particles to only include those within radius of centre position.
+    
+    Parameters
+    ----------
+    tomogram_raw_data : list
+        Raw particle data in format [[[x,y,z], [rx,ry,rz]], ...]
+    centre : np.array
+        centre position [x, y, z]
+    radius : float
+        Maximum distance from centre
+        
+    Returns
+    -------
+    tuple
+        (filtered_data, filtered_indices) where filtered_indices are the original indices
+    """
+    filtered_data = []
+    filtered_indices = []
+    
+    for i, particle in enumerate(tomogram_raw_data):
+        position = np.array(particle[0])  # [x, y, z]
+        distance = np.linalg.norm(position - centre)
+        
+        if distance <= radius:
+            filtered_data.append(particle)
+            filtered_indices.append(i)
+    
+    return filtered_data, filtered_indices
+
+def main():
+    """Main function to create filtered dataset."""
+    print(f"Loading data from {DATA_FILE}")
+    
+    mat_full = scipy.io.loadmat(str(DATA_FILE), simplify_cells=True, mat_dtype=True)
+    mat_geom = mat_full["subTomoMeta"]["cycle000"]["geometry"]
+    
+    print(f"Loaded geometry data with {len(mat_geom)} tomograms")
+    
+    if TEST_TOMO_NAME not in mat_geom:
+        print(f"Error: Tomogram {TEST_TOMO_NAME} not found in the data")
+        return
+    
+    tomo_raw_data = read_emc_tomogram_raw_data(mat_geom[TEST_TOMO_NAME], TEST_TOMO_NAME)
+    if tomo_raw_data is None:
+        print(f"Error: Failed to extract data for tomogram: {TEST_TOMO_NAME}")
+        return
+    
+    print(f"Original dataset has {len(tomo_raw_data)} particles")
+    
+    print(f"Filtering particles within {FILTER_RADIUS} units of {FILTER_centre}")
+    filtered_data, filtered_indices = filter_particles_by_position(
+        tomo_raw_data, FILTER_centre, FILTER_RADIUS
+    )
+    
+    print(f"Filtered dataset has {len(filtered_data)} particles")
+    print(f"Filtered indices: {filtered_indices[:10]}{'...' if len(filtered_indices) > 10 else ''}")
+    
+    if len(filtered_data) == 0:
+        print("Error: No particles found within the specified radius")
+        return
+    
+    original_tomo_data = mat_geom[TEST_TOMO_NAME]
+    filtered_tomo_data = []
+    
+    for idx in filtered_indices:
+        filtered_tomo_data.append(original_tomo_data[idx])
+    
+    new_mat_full = mat_full.copy()
+    new_mat_full["subTomoMeta"]["cycle000"]["geometry"] = {TEST_TOMO_NAME: filtered_tomo_data}
+    
+    print(f"Saving filtered dataset to {OUTPUT_FILE}")
+    scipy.io.savemat(str(OUTPUT_FILE), mdict=new_mat_full)
+    
+    print(f"✓ Filtered dataset saved successfully!")
+    print(f"  - Original particles: {len(tomo_raw_data)}")
+    print(f"  - Filtered particles: {len(filtered_data)}")
+    print(f"  - Reduction: {(1 - len(filtered_data)/len(tomo_raw_data))*100:.1f}%")
+    
+    positions = np.array([particle[0] for particle in filtered_data])
+    print(f"  - Position range:")
+    print(f"    X: {positions[:, 0].min():.1f} to {positions[:, 0].max():.1f}")
+    print(f"    Y: {positions[:, 1].min():.1f} to {positions[:, 1].max():.1f}")
+    print(f"    Z: {positions[:, 2].min():.1f} to {positions[:, 2].max():.1f}")
+
+if __name__ == "__main__":
+    main()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -243,7 +243,7 @@ def log_test_start(test_name: str, logger: Optional[logging.Logger] = None) -> N
     if logger is None:
         logger = logging.getLogger()
 
-    logger.info(f"🧪 Starting test: {test_name}")
+    logger.info(f"Starting test: {test_name}")
 
 
 def log_test_success(test_name: str, logger: Optional[logging.Logger] = None) -> None:
@@ -260,7 +260,7 @@ def log_test_success(test_name: str, logger: Optional[logging.Logger] = None) ->
     if logger is None:
         logger = logging.getLogger()
 
-    logger.info(f"✅ Test completed successfully: {test_name}")
+    logger.info(f"PASSED Test: {test_name}")
 
 
 def log_test_failure(
@@ -281,4 +281,4 @@ def log_test_failure(
     if logger is None:
         logger = logging.getLogger()
 
-    logger.error(f"❌ Test failed: {test_name} - {error}")
+    logger.error(f"FAILED Test: {test_name} - {error}")

--- a/test/unit/test_cleaning_with_flips.py
+++ b/test/unit/test_cleaning_with_flips.py
@@ -30,7 +30,7 @@ from magpiem.io.io_utils import (
     read_emc_mat,
 )
 from magpiem.processing.classes.cleaner import Cleaner
-from magpiem.processing.cpp_integration import clean_tomo_with_cpp
+from magpiem.processing.cpp_integration import clean_tomo_with_cpp, clean_and_detect_flips_with_cpp
 from magpiem.plotting.plotting_utils import create_lattice_plot_from_raw_data
 
 logger = setup_test_logging()
@@ -69,41 +69,110 @@ def test_cleaning_with_flips():
         test_cleaner = Cleaner.from_user_params(*TEST_CLEANER_VALUES, allow_flips=True)
 
         logger.info(f"Cleaner allow_flips set to: {test_cleaner.allow_flips}")
+        
+        # Run C++ cleaning with flips enabled
         logger.info("Running C++ cleaning with flips enabled...")
+        cpp_lattice_data = clean_tomo_with_cpp(tomo_raw_data, test_cleaner)
+        logger.info(f"C++ cleaning completed. Found {len(cpp_lattice_data)} lattices")
 
-        lattice_data = clean_tomo_with_cpp(tomo_raw_data, test_cleaner)
+        # Run C++ cleaning and flip detection
+        logger.info("Running C++ cleaning and flip detection...")
+        cpp_flip_lattice_data, cpp_flipped_indices = clean_and_detect_flips_with_cpp(tomo_raw_data, test_cleaner)
+        logger.info(f"C++ flip detection completed. Found {len(cpp_flip_lattice_data)} lattices and {len(cpp_flipped_indices)} flipped particles")
 
-        logger.info(f"Cleaning completed. Found {len(lattice_data)} lattices")
+        # Run Python implementation for comparison
+        logger.info("Running Python implementation for comparison...")
+        test_tomo = read_single_tomogram(str(FLIPPED_DATA_FILE), TEST_TOMO_NAME)
+        if test_tomo is None:
+            raise ValueError(f"Failed to load tomogram: {TEST_TOMO_NAME}")
+        
+        test_tomo.cleaning_params = test_cleaner
+        test_tomo.find_particle_neighbours()
+        
+        # Manually assign all particles to lattice 1 for Python comparison
+        for particle in test_tomo.all_particles:
+            particle.set_lattice(1)
+        test_tomo.lattices[1] = test_tomo.all_particles
+        
+        # Run Python cleaning
+        test_tomo.clean_particles()
+        python_lattice_data = {lattice_id: list(particles) for lattice_id, particles in test_tomo.lattices.items()}
+        logger.info(f"Python cleaning completed. Found {len(python_lattice_data)} lattices")
+        
+        # Run Python flip detection
+        python_flipped_particles = test_tomo.find_flipped_particles()
+        python_flipped_indices = [test_tomo.all_particles.index(p) for p in python_flipped_particles]
+        logger.info(f"Python flip detection completed. Found {len(python_flipped_indices)} flipped particles")
 
-        for lattice_id, particles in lattice_data.items():
+        # Log results for comparison
+        for lattice_id, particles in cpp_lattice_data.items():
             if lattice_id == 0:
-                logger.debug(
-                    f"Lattice {lattice_id}: {len(particles)} unassigned particles"
-                )
+                logger.debug(f"C++ Lattice {lattice_id}: {len(particles)} unassigned particles")
             else:
-                logger.debug(f"Lattice {lattice_id}: {len(particles)} particles")
+                logger.debug(f"C++ Lattice {lattice_id}: {len(particles)} particles")
+                
+        for lattice_id, particles in python_lattice_data.items():
+            if lattice_id == 0:
+                logger.debug(f"Python Lattice {lattice_id}: {len(particles)} unassigned particles")
+            else:
+                logger.debug(f"Python Lattice {lattice_id}: {len(particles)} particles")
 
-        # Generate cone plot directly from raw data and lattice results
-        logger.info("Generating cone plot for inspection...")
-        fig = create_lattice_plot_from_raw_data(
+        # Generate comparison plots
+        logger.info("Generating comparison plots...")
+        
+        # C++ cleaning plot
+        cpp_fig = create_lattice_plot_from_raw_data(
             tomogram_raw_data=tomo_raw_data,
-            lattice_data=lattice_data,
+            lattice_data=cpp_lattice_data,
             cone_size=10.0,
             show_removed_particles=False,
         )
-
-        output_html = test_root / "logs" / "cleaning_with_flips_result.html"
-        logger.info(f"Saving interactive plot to {output_html}")
-        fig.write_html(str(output_html))
+        cpp_output_html = test_root / "logs" / "cleaning_with_flips_cpp_result.html"
+        logger.info(f"Saving C++ interactive plot to {cpp_output_html}")
+        cpp_fig.write_html(str(cpp_output_html))
+        
+        # Python cleaning plot
+        python_fig = create_lattice_plot_from_raw_data(
+            tomogram_raw_data=tomo_raw_data,
+            lattice_data=python_lattice_data,
+            cone_size=10.0,
+            show_removed_particles=False,
+        )
+        python_output_html = test_root / "logs" / "cleaning_with_flips_python_result.html"
+        logger.info(f"Saving Python interactive plot to {python_output_html}")
+        python_fig.write_html(str(python_output_html))
+        
+        # Combined comparison plot
+        combined_fig = create_lattice_plot_from_raw_data(
+            tomogram_raw_data=tomo_raw_data,
+            lattice_data=cpp_lattice_data,
+            cone_size=10.0,
+            show_removed_particles=False,
+        )
+        combined_output_html = test_root / "logs" / "cleaning_with_flips_combined_result.html"
+        logger.info(f"Saving combined interactive plot to {combined_output_html}")
+        combined_fig.write_html(str(combined_output_html))
 
         log_test_success(test_name, logger)
         logger.info(f"Cleaning with flips completed successfully")
-        logger.info(f"Interactive plot saved as: {output_html}")
+        logger.info(f"C++ interactive plot saved as: {cpp_output_html}")
+        logger.info(f"Python interactive plot saved as: {python_output_html}")
+        logger.info(f"Combined interactive plot saved as: {combined_output_html}")
+        
+        # Log comparison results
+        logger.info(f"C++ found {len(cpp_lattice_data)} lattices, {len(cpp_flipped_indices)} flipped particles")
+        logger.info(f"Python found {len(python_lattice_data)} lattices, {len(python_flipped_indices)} flipped particles")
+        logger.info(f"Flipped particles match: {set(cpp_flipped_indices) == set(python_flipped_indices)}")
 
         # Basic assertions
-        assert fig is not None
-        assert len(lattice_data) > 1
-        assert output_html.exists()
+        assert cpp_fig is not None
+        assert python_fig is not None
+        assert combined_fig is not None
+        assert len(cpp_lattice_data) > 1
+        assert len(python_lattice_data) > 1
+        assert cpp_output_html.exists()
+        assert python_output_html.exists()
+        assert combined_output_html.exists()
 
     except Exception as e:
         log_test_failure(test_name, e, logger)

--- a/test/unit/test_cleaning_with_flips.py
+++ b/test/unit/test_cleaning_with_flips.py
@@ -24,7 +24,11 @@ from test_utils import (
 )
 
 setup_test_environment()
-from magpiem.io.io_utils import read_single_tomogram, read_emc_tomogram_raw_data, read_emc_mat
+from magpiem.io.io_utils import (
+    read_single_tomogram,
+    read_emc_tomogram_raw_data,
+    read_emc_mat,
+)
 from magpiem.processing.classes.cleaner import Cleaner
 from magpiem.processing.cpp_integration import clean_tomo_with_cpp
 from magpiem.plotting.plotting_utils import create_lattice_plot_from_raw_data
@@ -45,33 +49,37 @@ def test_cleaning_with_flips():
         # Check if flipped data exists
         if not FLIPPED_DATA_FILE.exists():
             raise FileNotFoundError(f"Flipped test data not found: {FLIPPED_DATA_FILE}")
-        
+
         logger.info(f"Loading flipped test data from {FLIPPED_DATA_FILE}")
-        
+
         # Load the raw tomogram data for C++ processing
-        
+
         full_geom = read_emc_mat(str(FLIPPED_DATA_FILE))
         if full_geom is None:
             raise ValueError("Failed to load flipped mat file")
-        
-        tomo_raw_data = read_emc_tomogram_raw_data(full_geom[TEST_TOMO_NAME], TEST_TOMO_NAME)
+
+        tomo_raw_data = read_emc_tomogram_raw_data(
+            full_geom[TEST_TOMO_NAME], TEST_TOMO_NAME
+        )
         if tomo_raw_data is None:
             raise ValueError(f"Failed to extract data for tomogram: {TEST_TOMO_NAME}")
-        
+
         logger.info(f"Loaded raw data with {len(tomo_raw_data)} particles")
 
         test_cleaner = Cleaner.from_user_params(*TEST_CLEANER_VALUES, allow_flips=True)
-        
+
         logger.info(f"Cleaner allow_flips set to: {test_cleaner.allow_flips}")
         logger.info("Running C++ cleaning with flips enabled...")
-        
+
         lattice_data = clean_tomo_with_cpp(tomo_raw_data, test_cleaner)
-        
+
         logger.info(f"Cleaning completed. Found {len(lattice_data)} lattices")
-        
+
         for lattice_id, particles in lattice_data.items():
             if lattice_id == 0:
-                logger.debug(f"Lattice {lattice_id}: {len(particles)} unassigned particles")
+                logger.debug(
+                    f"Lattice {lattice_id}: {len(particles)} unassigned particles"
+                )
             else:
                 logger.debug(f"Lattice {lattice_id}: {len(particles)} particles")
 
@@ -91,7 +99,7 @@ def test_cleaning_with_flips():
         log_test_success(test_name, logger)
         logger.info(f"Cleaning with flips completed successfully")
         logger.info(f"Interactive plot saved as: {output_html}")
-        
+
         # Basic assertions
         assert fig is not None
         assert len(lattice_data) > 1

--- a/test/unit/test_cleaning_with_flips.py
+++ b/test/unit/test_cleaning_with_flips.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Test for cleaning functionality with particle flipping enabled.
+
+Loads test_data_flipped.mat and runs cleaning with allow_flips enabled,
+saving the result as an HTML file for inspection.
+"""
+
+import sys
+from pathlib import Path
+
+# Add test utilities to path
+test_root = Path(__file__).parent.parent
+sys.path.insert(0, str(test_root))
+
+from test_utils import (
+    TestConfig,
+    setup_test_logging,
+    get_test_data_path,
+    log_test_start,
+    log_test_success,
+    log_test_failure,
+    setup_test_environment,
+)
+
+setup_test_environment()
+from magpiem.io.io_utils import read_single_tomogram, read_emc_tomogram_raw_data, read_emc_mat
+from magpiem.processing.classes.cleaner import Cleaner
+from magpiem.processing.cpp_integration import clean_tomo_with_cpp
+from magpiem.plotting.plotting_utils import create_lattice_plot_from_raw_data
+
+logger = setup_test_logging()
+
+FLIPPED_DATA_FILE = test_root / "data" / "test_data_flipped.mat"
+TEST_TOMO_NAME = TestConfig.TEST_TOMO_STANDARD
+TEST_CLEANER_VALUES = TestConfig.TEST_CLEANER_VALUES
+
+
+def test_cleaning_with_flips():
+    """Test cleaning functionality with particle flipping enabled."""
+    test_name = "Cleaning with Flips Test"
+    log_test_start(test_name, logger)
+
+    try:
+        # Check if flipped data exists
+        if not FLIPPED_DATA_FILE.exists():
+            raise FileNotFoundError(f"Flipped test data not found: {FLIPPED_DATA_FILE}")
+        
+        logger.info(f"Loading flipped test data from {FLIPPED_DATA_FILE}")
+        
+        # Load the raw tomogram data for C++ processing
+        
+        full_geom = read_emc_mat(str(FLIPPED_DATA_FILE))
+        if full_geom is None:
+            raise ValueError("Failed to load flipped mat file")
+        
+        tomo_raw_data = read_emc_tomogram_raw_data(full_geom[TEST_TOMO_NAME], TEST_TOMO_NAME)
+        if tomo_raw_data is None:
+            raise ValueError(f"Failed to extract data for tomogram: {TEST_TOMO_NAME}")
+        
+        logger.info(f"Loaded raw data with {len(tomo_raw_data)} particles")
+
+        test_cleaner = Cleaner.from_user_params(*TEST_CLEANER_VALUES, allow_flips=True)
+        
+        logger.info(f"Cleaner allow_flips set to: {test_cleaner.allow_flips}")
+        logger.info("Running C++ cleaning with flips enabled...")
+        
+        lattice_data = clean_tomo_with_cpp(tomo_raw_data, test_cleaner)
+        
+        logger.info(f"Cleaning completed. Found {len(lattice_data)} lattices")
+        
+        for lattice_id, particles in lattice_data.items():
+            if lattice_id == 0:
+                logger.debug(f"Lattice {lattice_id}: {len(particles)} unassigned particles")
+            else:
+                logger.debug(f"Lattice {lattice_id}: {len(particles)} particles")
+
+        # Generate cone plot directly from raw data and lattice results
+        logger.info("Generating cone plot for inspection...")
+        fig = create_lattice_plot_from_raw_data(
+            tomogram_raw_data=tomo_raw_data,
+            lattice_data=lattice_data,
+            cone_size=10.0,
+            show_removed_particles=False,
+        )
+
+        output_html = test_root / "logs" / "cleaning_with_flips_result.html"
+        logger.info(f"Saving interactive plot to {output_html}")
+        fig.write_html(str(output_html))
+
+        log_test_success(test_name, logger)
+        logger.info(f"Cleaning with flips completed successfully")
+        logger.info(f"Interactive plot saved as: {output_html}")
+        
+        # Basic assertions
+        assert fig is not None
+        assert len(lattice_data) > 1
+        assert output_html.exists()
+
+    except Exception as e:
+        log_test_failure(test_name, e, logger)
+        raise
+
+
+if __name__ == "__main__":
+    test_cleaning_with_flips()
+    print("Test completed successfully!")

--- a/test/unit/test_find_flipped_particles.py
+++ b/test/unit/test_find_flipped_particles.py
@@ -146,10 +146,12 @@ def find_actually_flipped_particles(test_tomo):
     return actually_flipped, original_tomo
 
 
-def validate_flip_detection_results(detected_particle_ids, actually_flipped, implementation_name):
+def validate_flip_detection_results(
+    detected_particle_ids, actually_flipped, implementation_name
+):
     """
     Common validation function for flip detection results from any implementation.
-    
+
     Parameters
     ----------
     detected_particle_ids : list
@@ -183,14 +185,14 @@ def validate_flip_detection_results(detected_particle_ids, actually_flipped, imp
 def run_python_flip_detection(test_tomo):
     """Run the Python flip detection implementation and return results."""
     logger.info("Running Python flip detection...")
-    
+
     # Run Python flip detection
     flipped_particles = test_tomo.find_flipped_particles()
     logger.info(f"Python found {len(flipped_particles)} flipped particles")
-    
+
     # Convert to particle IDs
     python_flipped_particle_ids = [p.particle_id for p in flipped_particles]
-    
+
     return flipped_particles, python_flipped_particle_ids
 
 
@@ -345,10 +347,14 @@ def test_find_flipped_particles():
         actually_flipped, original_tomo = find_actually_flipped_particles(test_tomo)
 
         # Run Python flip detection
-        flipped_particles, python_flipped_particle_ids = run_python_flip_detection(test_tomo)
-        
+        flipped_particles, python_flipped_particle_ids = run_python_flip_detection(
+            test_tomo
+        )
+
         # Debug: Check which particles are being identified as flipped
-        logger.info(f"Python flipped particle IDs (first 10): {python_flipped_particle_ids[:10]}")
+        logger.info(
+            f"Python flipped particle IDs (first 10): {python_flipped_particle_ids[:10]}"
+        )
         for particle in flipped_particles[:5]:  # Log first 5 for debugging
             logger.debug(
                 f"Flipped particle ID: {particle.particle_id}, Lattice: {particle.lattice}, Direction: {getattr(particle, 'direction', 'None')}"
@@ -359,19 +365,24 @@ def test_find_flipped_particles():
             test_tomo, test_cleaner
         )
 
-
         # Create visualization
         fig, output_html = create_visualization(
             test_tomo, flipped_particles, debug_flipped_indices
         )
 
-                # Validate both implementations using common validation function
+        # Validate both implementations using common validation function
         if actually_flipped:
-            validate_flip_detection_results(python_flipped_particle_ids, actually_flipped, "Python")
-            validate_flip_detection_results(debug_flipped_particle_ids, actually_flipped, "C++")
+            validate_flip_detection_results(
+                python_flipped_particle_ids, actually_flipped, "Python"
+            )
+            validate_flip_detection_results(
+                debug_flipped_particle_ids, actually_flipped, "C++"
+            )
 
         # Compare Python and C++ results
-        compare_python_cpp_results(python_flipped_particle_ids, debug_flipped_particle_ids)
+        compare_python_cpp_results(
+            python_flipped_particle_ids, debug_flipped_particle_ids
+        )
 
         # Validate final results
         validate_test_results(

--- a/test/unit/test_find_flipped_particles.py
+++ b/test/unit/test_find_flipped_particles.py
@@ -26,6 +26,7 @@ setup_test_environment()
 
 from magpiem.io.io_utils import read_single_tomogram
 from magpiem.processing.classes.cleaner import Cleaner
+from magpiem.processing.cpp_integration import clean_and_detect_flips_with_cpp, debug_flip_detection_with_cpp
 from magpiem.plotting.plotting_utils import (
     create_lattice_plot_from_raw_data,
     create_cone_traces,
@@ -40,73 +41,254 @@ TEST_TOMO_NAME = TestConfig.TEST_TOMO_STANDARD
 TEST_CLEANER_VALUES = TestConfig.TEST_CLEANER_VALUES
 
 
+def create_test_cleaner() -> Cleaner:
+    """Create cleaning parameters optimized for small test dataset."""
+    (
+        cc_thresh,
+        min_neigh,
+        min_lattice_size,
+        target_dist,
+        dist_tol,
+        target_ori,
+        ori_tol,
+        target_curv,
+        curv_tol,
+    ) = TEST_CLEANER_VALUES
+
+    # More lenient parameters to ensure no issues with cleaning - not what we are testing here
+    dist_range = Cleaner.dist_range(target_dist, dist_tol + 10.0)
+    ori_range = Cleaner.ang_range_dotprod(target_ori, 60)
+    curv_range = Cleaner.ang_range_dotprod(target_curv, 60)
+    flipped_ori_range = tuple(-x for x in reversed(ori_range))
+
+    return Cleaner(
+        cc_thresh=cc_thresh,
+        min_neighbours=0,
+        min_lattice_size=1,
+        dist_range=dist_range,
+        ori_range=ori_range,
+        curv_range=curv_range,
+        allow_flips=True,
+        flipped_ori_range=flipped_ori_range,
+    )
+
+
+def setup_test_tomogram():
+    """Load and setup the test tomogram with cleaning parameters."""
+    if not TEST_DATA_FILE.exists():
+        raise FileNotFoundError(f"Flipped test data not found: {TEST_DATA_FILE}")
+
+    logger.info(f"Loading flipped test data from {TEST_DATA_FILE}")
+    test_tomo = read_single_tomogram(str(TEST_DATA_FILE), TEST_TOMO_NAME)
+    if test_tomo is None:
+        raise ValueError(f"Failed to load tomogram: {TEST_TOMO_NAME}")
+
+    logger.info(f"Loaded tomogram with {len(test_tomo.all_particles)} particles")
+
+    # Create and assign cleaning parameters
+    test_cleaner = create_test_cleaner()
+    test_tomo.cleaning_params = test_cleaner
+
+    logger.info(f"Assigned cleaning parameters: {test_cleaner}")
+    logger.info(f"Allow flips: {test_cleaner.allow_flips}")
+
+    # Run neighbour finding (required for flip detection)
+    logger.info("Running neighbour finding...")
+    test_tomo.find_particle_neighbours()
+    logger.info("Neighbour finding completed")
+
+    # Manually assign all particles to lattice 1
+    for particle in test_tomo.all_particles:
+        particle.set_lattice(1)
+    test_tomo.lattices[1] = test_tomo.all_particles
+
+    logger.info(f"Manually assigned {len(test_tomo.all_particles)} particles to lattice 1")
+
+    return test_tomo, test_cleaner
+
+
+def find_actually_flipped_particles(test_tomo):
+    """Compare with original dataset to identify actually flipped particles."""
+    logger.info("Comparing with original dataset to identify actually flipped particles...")
+
+    original_tomo = read_single_tomogram(str(ORIGINAL_DATA_FILE), TEST_TOMO_NAME)
+    if not original_tomo:
+        logger.info("No actually flipped particles found - cannot calculate overlap percentage")
+        return [], []
+
+    # Create particle lookup by ID
+    orig_particles = {p.particle_id: p for p in original_tomo.all_particles}
+    flip_particles = {p.particle_id: p for p in test_tomo.all_particles}
+
+    actually_flipped = []
+    for particle_id in orig_particles:
+        if particle_id in flip_particles:
+            orig_particle = orig_particles[particle_id]
+            flip_particle = flip_particles[particle_id]
+
+            # Use the dot_orientation method to compare orientations
+            dot_prod = orig_particle.dot_orientation(flip_particle)
+            if abs(dot_prod + 1) < 0.1:  # Close to -1 means 180° rotation
+                actually_flipped.append(particle_id)
+
+    logger.info(f"Found {len(actually_flipped)} actually flipped particles in dataset")
+    logger.info(f"Actually flipped particle IDs: {actually_flipped}")
+
+    return actually_flipped, original_tomo
+
+
+def validate_python_flip_detection(flipped_particles, actually_flipped):
+    """Validate that Python flip detection found the correct particles."""
+    # Check overlap with our detected flipped particles
+    detected_ids = [p.particle_id for p in flipped_particles]
+    overlap = set(actually_flipped) & set(detected_ids)
+    logger.info(f"Overlap between detected and truly flipped particles: {len(overlap)} particles")
+
+    assert len(actually_flipped) > 0, "No flipped particles found from original dataset, test is invalid"
+    overlap_percentage = len(overlap) / len(actually_flipped) * 100
+    logger.info(f"Overlap percentage: {overlap_percentage:.1f}%")
+
+    # Test should fail if overlap isn't perfect
+    assert len(overlap) == len(actually_flipped), f"Expected perfect overlap but got {len(overlap)}/{len(actually_flipped)} particles"
+    assert set(detected_ids) == set(actually_flipped), f"Detected particles {set(detected_ids)} don't match actually flipped particles {set(actually_flipped)}"
+
+
+def test_cpp_implementation(test_tomo, test_cleaner, actually_flipped):
+    """Test the C++ debug implementation and validate results."""
+    logger.info("Testing C++ debug implementation...")
+    
+    # Prepare raw data for C++ function
+    raw_data = []
+    for particle in test_tomo.all_particles:
+        raw_data.append([particle.position, particle.orientation])
+    
+    # Run C++ debug implementation
+    debug_lattice_data, debug_flipped_indices = debug_flip_detection_with_cpp(raw_data, test_cleaner)
+    
+    logger.info(f"Debug C++ found {len(debug_flipped_indices)} flipped particles")
+    
+    # Convert C++ indices to particle IDs
+    all_particles_list = list(test_tomo.all_particles)
+    debug_flipped_particle_ids = []
+    for idx in debug_flipped_indices:
+        debug_flipped_particle_ids.append(all_particles_list[idx].particle_id)
+    
+    # Compare C++ debug results with actually flipped particles
+    if actually_flipped:
+        debug_overlap = set(debug_flipped_particle_ids) & set(actually_flipped)
+        
+        # Test should fail if C++ debug overlap isn't perfect
+        assert len(debug_overlap) == len(actually_flipped), f"Debug C++ expected perfect overlap but got {len(debug_overlap)}/{len(actually_flipped)} particles"
+        assert set(debug_flipped_particle_ids) == set(actually_flipped), f"Debug C++ detected particles {set(debug_flipped_particle_ids)} don't match actually flipped particles {set(actually_flipped)}"
+    
+    return debug_flipped_indices, debug_flipped_particle_ids
+
+
+def compare_python_cpp_results(python_flipped_ids, debug_flipped_particle_ids):
+    """Compare Python and C++ results to ensure they match."""
+    # Python and C++ debug should give identical results
+    assert set(python_flipped_ids) == set(debug_flipped_particle_ids), f"Python and Debug C++ results don't match: Python={set(python_flipped_ids)}, Debug C++={set(debug_flipped_particle_ids)}"
+
+
+def create_visualization(test_tomo, flipped_particles, debug_flipped_indices):
+    """Create and save the visualization plot."""
+    logger.info("Visualising...")
+
+    # Create the base lattice plot
+    fig = test_tomo.plot_all_lattices(
+        cone_size=10.0,
+        cone_fix=True,
+        showing_removed_particles=False,
+    )
+
+    # Add Python flipped particles in red
+    if flipped_particles:
+        python_flipped_positions = []
+        python_flipped_orientations = []
+
+        for particle in flipped_particles:
+            python_flipped_positions.append(particle.position)
+            python_flipped_orientations.append(particle.orientation)
+
+        if python_flipped_positions:
+            python_flipped_positions = np.array(python_flipped_positions)
+            python_flipped_orientations = np.array(python_flipped_orientations)
+
+            python_flipped_trace = create_cone_traces(
+                positions=python_flipped_positions,
+                orientations=python_flipped_orientations,
+                cone_size=2.0,
+                colour="red",
+                opacity=0.9,
+                lattice_id=-1,  # Dummy ID for flipped particles
+            )
+            python_flipped_trace.name = "Python Flipped Particles"
+            fig.add_trace(python_flipped_trace)
+
+    # Add Debug C++ flipped particles in blue
+    if debug_flipped_indices:
+        debug_flipped_positions = []
+        debug_flipped_orientations = []
+        all_particles_list = list(test_tomo.all_particles)
+
+        for idx in debug_flipped_indices:
+            particle = all_particles_list[idx]
+            debug_flipped_positions.append(particle.position)
+            debug_flipped_orientations.append(particle.orientation)
+
+        if debug_flipped_positions:
+            debug_flipped_positions = np.array(debug_flipped_positions)
+            debug_flipped_orientations = np.array(debug_flipped_orientations)
+
+            debug_flipped_trace = create_cone_traces(
+                positions=debug_flipped_positions,
+                orientations=debug_flipped_orientations,
+                cone_size=2.0,
+                colour="blue",
+                opacity=0.9,
+                lattice_id=-2,  # Dummy ID for Debug C++ flipped particles
+            )
+            debug_flipped_trace.name = "Debug C++ Flipped Particles"
+            fig.add_trace(debug_flipped_trace)
+
+    # Save the plot
+    output_html = test_root / "logs" / "find_flipped_particles_result.html"
+    logger.info(f"Saving interactive plot to {output_html}")
+    fig.write_html(str(output_html))
+
+    return fig, output_html
+
+
+def validate_test_results(fig, output_html, flipped_particles, total_particles, debug_flipped_indices, python_flipped_ids, debug_flipped_particle_ids):
+    """Validate final test results and log summary."""
+    # Basic assertions
+    assert fig is not None, "Figure was not created"
+    assert output_html.exists(), "Output HTML file was not created"
+    assert isinstance(flipped_particles, list), f"Flipped particles returned as an incorrect type, {type(flipped_particles)}"
+
+    flipped_count = len(flipped_particles)
+    flipped_percentage = (flipped_count / total_particles * 100) if total_particles > 0 else 0
+
+    logger.info(f"Test completed successfully")
+    logger.info(f"Total particles: {total_particles}")
+    logger.info(f"Python flipped particles: {flipped_count} ({flipped_percentage:.1f}%)")
+    logger.info(f"Debug C++ flipped particles: {len(debug_flipped_indices)} ({len(debug_flipped_indices)/total_particles*100:.1f}%)")
+    logger.info(f"Python and Debug C++ results match: {set(python_flipped_ids) == set(debug_flipped_particle_ids)}")
+    logger.info(f"Interactive plot saved as: {output_html}")
+
+
 def test_find_flipped_particles():
     """Test the find_flipped_particles method with visualisation."""
     test_name = "Find Flipped Particles Test"
     log_test_start(test_name, logger)
 
     try:
-        if not TEST_DATA_FILE.exists():
-            raise FileNotFoundError(f"Flipped test data not found: {TEST_DATA_FILE}")
+        # Setup test data
+        test_tomo, test_cleaner = setup_test_tomogram()
 
-        logger.info(f"Loading flipped test data from {TEST_DATA_FILE}")
-
-        test_tomo = read_single_tomogram(str(TEST_DATA_FILE), TEST_TOMO_NAME)
-        if test_tomo is None:
-            raise ValueError(f"Failed to load tomogram: {TEST_TOMO_NAME}")
-
-        logger.info(f"Loaded tomogram with {len(test_tomo.all_particles)} particles")
-
-        # Create cleaning params manually
-        (
-            cc_thresh,
-            min_neigh,
-            min_lattice_size,
-            target_dist,
-            dist_tol,
-            target_ori,
-            ori_tol,
-            target_curv,
-            curv_tol,
-        ) = TEST_CLEANER_VALUES
-
-        dist_range = Cleaner.dist_range(target_dist, dist_tol)
-        ori_range = Cleaner.ang_range_dotprod(target_ori, ori_tol)
-        curv_range = Cleaner.ang_range_dotprod(target_curv, curv_tol)
-        flipped_ori_range = tuple(-x for x in reversed(ori_range))
-
-        test_cleaner = Cleaner(
-            cc_thresh=cc_thresh,
-            min_neighbours=min_neigh,
-            min_lattice_size=min_lattice_size,
-            dist_range=dist_range,
-            ori_range=ori_range,
-            curv_range=curv_range,
-            allow_flips=True,
-            flipped_ori_range=flipped_ori_range,
-        )
-        test_tomo.cleaning_params = test_cleaner
-
-        logger.info(f"Assigned cleaning parameters: {test_cleaner}")
-        logger.info(f"Allow flips: {test_cleaner.allow_flips}")
-
-        # Run neighbour finding (required for flip detection)
-        logger.info("Running neighbour finding...")
-        test_tomo.find_particle_neighbours()
-        logger.info("Neighbour finding completed")
-
-        # Manually assign all particles to lattice 1
-        for particle in test_tomo.all_particles:
-            particle.set_lattice(1)
-        test_tomo.lattices[1] = test_tomo.all_particles
-
-        logger.info(
-            f"Manually assigned {len(test_tomo.all_particles)} particles to lattice 1"
-        )
-
+        # Run Python flip detection
         logger.info("Finding flipped particles...")
         flipped_particles = test_tomo.find_flipped_particles()
-
         logger.info(f"Found {len(flipped_particles)} flipped particles")
 
         # Debug: Check which particles are being identified as flipped
@@ -114,118 +296,27 @@ def test_find_flipped_particles():
         logger.info(f"Flipped particle IDs (first 10): {flipped_particle_ids[:10]}")
 
         for particle in flipped_particles[:5]:  # Log first 5 for debugging
-            logger.debug(
-                f"Flipped particle ID: {particle.particle_id}, Lattice: {particle.lattice}, Direction: {getattr(particle, 'direction', 'None')}"
-            )
+            logger.debug(f"Flipped particle ID: {particle.particle_id}, Lattice: {particle.lattice}, Direction: {getattr(particle, 'direction', 'None')}")
 
-        # Compare with original dataset to find actually flipped particles
-        logger.info(
-            "Comparing with original dataset to identify actually flipped particles..."
-        )
+        # Find actually flipped particles from original dataset
+        actually_flipped, original_tomo = find_actually_flipped_particles(test_tomo)
 
-        # original, unflipped tomogram
-        original_tomo = read_single_tomogram(str(ORIGINAL_DATA_FILE), TEST_TOMO_NAME)
-        if original_tomo:
-            # Create particle lookup by ID
-            orig_particles = {p.particle_id: p for p in original_tomo.all_particles}
-            flip_particles = {p.particle_id: p for p in test_tomo.all_particles}
+        # Validate Python flip detection
+        if actually_flipped:
+            validate_python_flip_detection(flipped_particles, actually_flipped)
 
-            actually_flipped = []
-            for particle_id in orig_particles:
-                if particle_id in flip_particles:
-                    orig_particle = orig_particles[particle_id]
-                    flip_particle = flip_particles[particle_id]
+        # Test C++ implementation
+        debug_flipped_indices, debug_flipped_particle_ids = test_cpp_implementation(test_tomo, test_cleaner, actually_flipped)
 
-                    # Use the dot_orientation method to compare orientations
-                    dot_prod = orig_particle.dot_orientation(flip_particle)
-                    if abs(dot_prod + 1) < 0.1:  # Close to -1 means 180° rotation
-                        actually_flipped.append(particle_id)
+        # Compare Python and C++ results
+        python_flipped_ids = [p.particle_id for p in flipped_particles]
+        compare_python_cpp_results(python_flipped_ids, debug_flipped_particle_ids)
 
-            logger.info(
-                f"Found {len(actually_flipped)} actually flipped particles in dataset"
-            )
+        # Create visualization
+        fig, output_html = create_visualization(test_tomo, flipped_particles, debug_flipped_indices)
 
-            # Check overlap with our detected flipped particles
-            detected_ids = [p.particle_id for p in flipped_particles]
-            overlap = set(actually_flipped) & set(detected_ids)
-            logger.info(
-                f"Overlap between detected and truly flipped particles: {len(overlap)} particles"
-            )
-
-            assert (
-                len(actually_flipped) > 0
-            ), "No flipped particles found from original dataset, test is invalid"
-            overlap_percentage = len(overlap) / len(actually_flipped) * 100
-            logger.info(f"Overlap percentage: {overlap_percentage:.1f}%")
-
-            # Test should fail if overlap isn't perfect
-            assert len(overlap) == len(
-                actually_flipped
-            ), f"Expected perfect overlap but got {len(overlap)}/{len(actually_flipped)} particles"
-            assert set(detected_ids) == set(
-                actually_flipped
-            ), f"Detected particles {set(detected_ids)} don't match actually flipped particles {set(actually_flipped)}"
-        else:
-            logger.info(
-                "No actually flipped particles found - cannot calculate overlap percentage"
-            )
-
-        logger.info("Visualising...")
-
-        # Create the base lattice plot
-        fig = test_tomo.plot_all_lattices(
-            cone_size=10.0,
-            cone_fix=True,
-            showing_removed_particles=False,
-        )
-
-        # Add flipped particles in a different colour
-        if flipped_particles:
-            flipped_positions = []
-            flipped_orientations = []
-
-            for particle in flipped_particles:
-                flipped_positions.append(particle.position)
-                flipped_orientations.append(particle.orientation)
-
-            if flipped_positions:
-                flipped_positions = np.array(flipped_positions)
-                flipped_orientations = np.array(flipped_orientations)
-
-                flipped_cone_trace = create_cone_traces(
-                    positions=flipped_positions,
-                    orientations=flipped_orientations,
-                    cone_size=2.0,
-                    colour="red",
-                    opacity=0.9,
-                    lattice_id=-1,  # Dummy ID for flipped particles
-                )
-                flipped_cone_trace.name = "Flipped Particles"
-
-                fig.add_trace(flipped_cone_trace)
-
-        # Save the plot
-        output_html = test_root / "logs" / "find_flipped_particles_result.html"
-        logger.info(f"Saving interactive plot to {output_html}")
-        fig.write_html(str(output_html))
-
-        # Basic assertions
-        assert fig is not None, "Figure was not created"
-        assert output_html.exists(), "Output HTML file was not created"
-        assert isinstance(
-            flipped_particles, list
-        ), f"Flipped particles returned as an incorrect type, {type(flipped_particles)}"
-
-        total_particles = len(test_tomo.all_particles)
-        flipped_count = len(flipped_particles)
-        flipped_percentage = (
-            (flipped_count / total_particles * 100) if total_particles > 0 else 0
-        )
-
-        logger.info(f"Test completed successfully!")
-        logger.info(f"Total particles: {total_particles}")
-        logger.info(f"Flipped particles: {flipped_count} ({flipped_percentage:.1f}%)")
-        logger.info(f"Interactive plot saved as: {output_html}")
+        # Validate final results
+        validate_test_results(fig, output_html, flipped_particles, len(test_tomo.all_particles), debug_flipped_indices, python_flipped_ids, debug_flipped_particle_ids)
 
         log_test_success(test_name, logger)
 

--- a/test/unit/test_find_flipped_particles.py
+++ b/test/unit/test_find_flipped_particles.py
@@ -26,7 +26,10 @@ setup_test_environment()
 
 from magpiem.io.io_utils import read_single_tomogram
 from magpiem.processing.classes.cleaner import Cleaner
-from magpiem.processing.cpp_integration import clean_and_detect_flips_with_cpp, debug_flip_detection_with_cpp
+from magpiem.processing.cpp_integration import (
+    clean_and_detect_flips_with_cpp,
+    debug_flip_detection_with_cpp,
+)
 from magpiem.plotting.plotting_utils import (
     create_lattice_plot_from_raw_data,
     create_cone_traces,
@@ -102,18 +105,24 @@ def setup_test_tomogram():
         particle.set_lattice(1)
     test_tomo.lattices[1] = test_tomo.all_particles
 
-    logger.info(f"Manually assigned {len(test_tomo.all_particles)} particles to lattice 1")
+    logger.info(
+        f"Manually assigned {len(test_tomo.all_particles)} particles to lattice 1"
+    )
 
     return test_tomo, test_cleaner
 
 
 def find_actually_flipped_particles(test_tomo):
     """Compare with original dataset to identify actually flipped particles."""
-    logger.info("Comparing with original dataset to identify actually flipped particles...")
+    logger.info(
+        "Comparing with original dataset to identify actually flipped particles..."
+    )
 
     original_tomo = read_single_tomogram(str(ORIGINAL_DATA_FILE), TEST_TOMO_NAME)
     if not original_tomo:
-        logger.info("No actually flipped particles found - cannot calculate overlap percentage")
+        logger.info(
+            "No actually flipped particles found - cannot calculate overlap percentage"
+        )
         return [], []
 
     # Create particle lookup by ID
@@ -142,52 +151,68 @@ def validate_python_flip_detection(flipped_particles, actually_flipped):
     # Check overlap with our detected flipped particles
     detected_ids = [p.particle_id for p in flipped_particles]
     overlap = set(actually_flipped) & set(detected_ids)
-    logger.info(f"Overlap between detected and truly flipped particles: {len(overlap)} particles")
+    logger.info(
+        f"Overlap between detected and truly flipped particles: {len(overlap)} particles"
+    )
 
-    assert len(actually_flipped) > 0, "No flipped particles found from original dataset, test is invalid"
+    assert (
+        len(actually_flipped) > 0
+    ), "No flipped particles found from original dataset, test is invalid"
     overlap_percentage = len(overlap) / len(actually_flipped) * 100
     logger.info(f"Overlap percentage: {overlap_percentage:.1f}%")
 
     # Test should fail if overlap isn't perfect
-    assert len(overlap) == len(actually_flipped), f"Expected perfect overlap but got {len(overlap)}/{len(actually_flipped)} particles"
-    assert set(detected_ids) == set(actually_flipped), f"Detected particles {set(detected_ids)} don't match actually flipped particles {set(actually_flipped)}"
+    assert len(overlap) == len(
+        actually_flipped
+    ), f"Expected perfect overlap but got {len(overlap)}/{len(actually_flipped)} particles"
+    assert set(detected_ids) == set(
+        actually_flipped
+    ), f"Detected particles {set(detected_ids)} don't match actually flipped particles {set(actually_flipped)}"
 
 
 def test_cpp_implementation(test_tomo, test_cleaner, actually_flipped):
     """Test the C++ debug implementation and validate results."""
     logger.info("Testing C++ debug implementation...")
-    
+
     # Prepare raw data for C++ function
     raw_data = []
     for particle in test_tomo.all_particles:
         raw_data.append([particle.position, particle.orientation])
-    
+
     # Run C++ debug implementation
-    debug_lattice_data, debug_flipped_indices = debug_flip_detection_with_cpp(raw_data, test_cleaner)
-    
+    debug_lattice_data, debug_flipped_indices = debug_flip_detection_with_cpp(
+        raw_data, test_cleaner
+    )
+
     logger.info(f"Debug C++ found {len(debug_flipped_indices)} flipped particles")
-    
+
     # Convert C++ indices to particle IDs
     all_particles_list = list(test_tomo.all_particles)
     debug_flipped_particle_ids = []
     for idx in debug_flipped_indices:
         debug_flipped_particle_ids.append(all_particles_list[idx].particle_id)
-    
+
     # Compare C++ debug results with actually flipped particles
     if actually_flipped:
         debug_overlap = set(debug_flipped_particle_ids) & set(actually_flipped)
-        
+
         # Test should fail if C++ debug overlap isn't perfect
-        assert len(debug_overlap) == len(actually_flipped), f"Debug C++ expected perfect overlap but got {len(debug_overlap)}/{len(actually_flipped)} particles"
-        assert set(debug_flipped_particle_ids) == set(actually_flipped), f"Debug C++ detected particles {set(debug_flipped_particle_ids)} don't match actually flipped particles {set(actually_flipped)}"
-    
+        assert len(debug_overlap) == len(
+            actually_flipped
+        ), f"Debug C++ expected perfect overlap but got {len(debug_overlap)}/{len(actually_flipped)} particles"
+        assert set(debug_flipped_particle_ids) == set(
+            actually_flipped
+        ), f"Debug C++ detected particles {set(debug_flipped_particle_ids)} don't match actually flipped particles {set(actually_flipped)}"
+
     return debug_flipped_indices, debug_flipped_particle_ids
 
 
 def compare_python_cpp_results(python_flipped_ids, debug_flipped_particle_ids):
     """Compare Python and C++ results to ensure they match."""
     # Python and C++ debug should give identical results
-    assert set(python_flipped_ids) == set(debug_flipped_particle_ids), f"Python and Debug C++ results don't match: Python={set(python_flipped_ids)}, Debug C++={set(debug_flipped_particle_ids)}"
+    assert set(python_flipped_ids) == set(
+        debug_flipped_particle_ids
+    ), f"Python and Debug C++ results don't match: Python={set(python_flipped_ids)}, Debug C++={set(debug_flipped_particle_ids)}"
 
 
 def create_visualization(test_tomo, flipped_particles, debug_flipped_indices):
@@ -259,21 +284,39 @@ def create_visualization(test_tomo, flipped_particles, debug_flipped_indices):
     return fig, output_html
 
 
-def validate_test_results(fig, output_html, flipped_particles, total_particles, debug_flipped_indices, python_flipped_ids, debug_flipped_particle_ids):
+def validate_test_results(
+    fig,
+    output_html,
+    flipped_particles,
+    total_particles,
+    debug_flipped_indices,
+    python_flipped_ids,
+    debug_flipped_particle_ids,
+):
     """Validate final test results and log summary."""
     # Basic assertions
     assert fig is not None, "Figure was not created"
     assert output_html.exists(), "Output HTML file was not created"
-    assert isinstance(flipped_particles, list), f"Flipped particles returned as an incorrect type, {type(flipped_particles)}"
+    assert isinstance(
+        flipped_particles, list
+    ), f"Flipped particles returned as an incorrect type, {type(flipped_particles)}"
 
     flipped_count = len(flipped_particles)
-    flipped_percentage = (flipped_count / total_particles * 100) if total_particles > 0 else 0
+    flipped_percentage = (
+        (flipped_count / total_particles * 100) if total_particles > 0 else 0
+    )
 
     logger.info(f"Test completed successfully")
     logger.info(f"Total particles: {total_particles}")
-    logger.info(f"Python flipped particles: {flipped_count} ({flipped_percentage:.1f}%)")
-    logger.info(f"Debug C++ flipped particles: {len(debug_flipped_indices)} ({len(debug_flipped_indices)/total_particles*100:.1f}%)")
-    logger.info(f"Python and Debug C++ results match: {set(python_flipped_ids) == set(debug_flipped_particle_ids)}")
+    logger.info(
+        f"Python flipped particles: {flipped_count} ({flipped_percentage:.1f}%)"
+    )
+    logger.info(
+        f"Debug C++ flipped particles: {len(debug_flipped_indices)} ({len(debug_flipped_indices)/total_particles*100:.1f}%)"
+    )
+    logger.info(
+        f"Python and Debug C++ results match: {set(python_flipped_ids) == set(debug_flipped_particle_ids)}"
+    )
     logger.info(f"Interactive plot saved as: {output_html}")
 
 
@@ -296,7 +339,9 @@ def test_find_flipped_particles():
         logger.info(f"Flipped particle IDs (first 10): {flipped_particle_ids[:10]}")
 
         for particle in flipped_particles[:5]:  # Log first 5 for debugging
-            logger.debug(f"Flipped particle ID: {particle.particle_id}, Lattice: {particle.lattice}, Direction: {getattr(particle, 'direction', 'None')}")
+            logger.debug(
+                f"Flipped particle ID: {particle.particle_id}, Lattice: {particle.lattice}, Direction: {getattr(particle, 'direction', 'None')}"
+            )
 
         # Find actually flipped particles from original dataset
         actually_flipped, original_tomo = find_actually_flipped_particles(test_tomo)
@@ -306,17 +351,29 @@ def test_find_flipped_particles():
             validate_python_flip_detection(flipped_particles, actually_flipped)
 
         # Test C++ implementation
-        debug_flipped_indices, debug_flipped_particle_ids = test_cpp_implementation(test_tomo, test_cleaner, actually_flipped)
+        debug_flipped_indices, debug_flipped_particle_ids = test_cpp_implementation(
+            test_tomo, test_cleaner, actually_flipped
+        )
 
         # Compare Python and C++ results
         python_flipped_ids = [p.particle_id for p in flipped_particles]
         compare_python_cpp_results(python_flipped_ids, debug_flipped_particle_ids)
 
         # Create visualization
-        fig, output_html = create_visualization(test_tomo, flipped_particles, debug_flipped_indices)
+        fig, output_html = create_visualization(
+            test_tomo, flipped_particles, debug_flipped_indices
+        )
 
         # Validate final results
-        validate_test_results(fig, output_html, flipped_particles, len(test_tomo.all_particles), debug_flipped_indices, python_flipped_ids, debug_flipped_particle_ids)
+        validate_test_results(
+            fig,
+            output_html,
+            flipped_particles,
+            len(test_tomo.all_particles),
+            debug_flipped_indices,
+            python_flipped_ids,
+            debug_flipped_particle_ids,
+        )
 
         log_test_success(test_name, logger)
 

--- a/test/unit/test_find_flipped_particles.py
+++ b/test/unit/test_find_flipped_particles.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Test for the find_flipped_particles method in the Tomogram class.
+
+Loads flipped data, cleans, and finds flipped particles, plotting results.
+"""
+
+import sys
+from pathlib import Path
+
+# Add test utilities to path
+test_root = Path(__file__).parent.parent
+sys.path.insert(0, str(test_root))
+
+from test_utils import (
+    TestConfig,
+    setup_test_logging,
+    get_test_data_path,
+    log_test_start,
+    log_test_success,
+    log_test_failure,
+    setup_test_environment,
+)
+
+setup_test_environment()
+
+from magpiem.io.io_utils import read_single_tomogram
+from magpiem.processing.classes.cleaner import Cleaner
+from magpiem.plotting.plotting_utils import (
+    create_lattice_plot_from_raw_data,
+    create_cone_traces,
+)
+import numpy as np
+
+logger = setup_test_logging()
+
+TEST_DATA_FILE = get_test_data_path("test_data_flipped.mat")
+TEST_TOMO_NAME = TestConfig.TEST_TOMO_STANDARD
+TEST_CLEANER_VALUES = TestConfig.TEST_CLEANER_VALUES
+
+
+def test_find_flipped_particles():
+    """Test the find_flipped_particles method with visualisation."""
+    test_name = "Find Flipped Particles Test"
+    log_test_start(test_name, logger)
+
+    try:
+        if not TEST_DATA_FILE.exists():
+            raise FileNotFoundError(f"Flipped test data not found: {TEST_DATA_FILE}")
+
+        logger.info(f"Loading flipped test data from {TEST_DATA_FILE}")
+
+        test_tomo = read_single_tomogram(str(TEST_DATA_FILE), TEST_TOMO_NAME)
+        if test_tomo is None:
+            raise ValueError(f"Failed to load tomogram: {TEST_TOMO_NAME}")
+
+        logger.info(f"Loaded tomogram with {len(test_tomo.all_particles)} particles")
+
+        # Create cleaning params manually
+        (
+            cc_thresh,
+            min_neigh,
+            min_lattice_size,
+            target_dist,
+            dist_tol,
+            target_ori,
+            ori_tol,
+            target_curv,
+            curv_tol,
+        ) = TEST_CLEANER_VALUES
+
+        dist_range = Cleaner.dist_range(target_dist, dist_tol)
+        ori_range = Cleaner.ang_range_dotprod(target_ori, ori_tol)
+        curv_range = Cleaner.ang_range_dotprod(target_curv, curv_tol)
+        flipped_ori_range = tuple(-x for x in reversed(ori_range))
+
+        test_cleaner = Cleaner(
+            cc_thresh=cc_thresh,
+            min_neighbours=min_neigh,
+            min_lattice_size=min_lattice_size,
+            dist_range=dist_range,
+            ori_range=ori_range,
+            curv_range=curv_range,
+            allow_flips=True,
+            flipped_ori_range=flipped_ori_range,
+        )
+        test_tomo.cleaning_params = test_cleaner
+
+        logger.info(f"Assigned cleaning parameters: {test_cleaner}")
+        logger.info(f"Allow flips: {test_cleaner.allow_flips}")
+
+        logger.info("Cleaning...")
+        lattice_data = test_tomo.autoclean()
+
+        logger.info(f"Cleaning complete. Found {len(lattice_data)} lattices")
+        for lattice_id, particles in lattice_data.items():
+            if lattice_id == 0:
+                logger.debug(
+                    f"Lattice {lattice_id}: {len(particles)} unassigned particles"
+                )
+            else:
+                logger.debug(f"Lattice {lattice_id}: {len(particles)} particles")
+
+        logger.info("Finding flipped particles...")
+        flipped_particles = test_tomo.find_flipped_particles()
+
+        logger.info(f"Found {len(flipped_particles)} flipped particles")
+        for particle in flipped_particles:
+            logger.debug(f"Flipped particle ID: {particle.particle_id}")
+
+        # Create visualisation with flipped particles highlighted
+        logger.info("Visualising...")
+
+        # Create the base lattice plot
+        fig = test_tomo.plot_all_lattices(
+            cone_size=10.0,
+            cone_fix=True,
+            showing_removed_particles=False,
+        )
+
+        # Add flipped particles in a different colour
+        if flipped_particles:
+            flipped_positions = []
+            flipped_orientations = []
+
+            for particle in flipped_particles:
+                flipped_positions.append(particle.position)
+                flipped_orientations.append(particle.orientation)
+
+            if flipped_positions:
+                flipped_positions = np.array(flipped_positions)
+                flipped_orientations = np.array(flipped_orientations)
+
+                flipped_cone_trace = create_cone_traces(
+                    positions=flipped_positions,
+                    orientations=flipped_orientations,
+                    cone_size=2.0,
+                    colour="red",
+                    opacity=0.9,
+                    lattice_id=-1,  # Dummy ID for flipped particles
+                )
+                flipped_cone_trace.name = "Flipped Particles"
+
+                fig.add_trace(flipped_cone_trace)
+
+        # Save the plot
+        output_html = test_root / "logs" / "find_flipped_particles_result.html"
+        logger.info(f"Saving interactive plot to {output_html}")
+        fig.write_html(str(output_html))
+
+        # Basic assertions
+        assert fig is not None, "Figure was not created"
+        assert output_html.exists(), "Output HTML file was not created"
+        assert isinstance(
+            flipped_particles, list
+        ), f"Flipped particles returned as an incorrect type, {type(flipped_particles)}"
+
+        total_particles = len(test_tomo.all_particles)
+        flipped_count = len(flipped_particles)
+        flipped_percentage = (
+            (flipped_count / total_particles * 100) if total_particles > 0 else 0
+        )
+
+        logger.info(f"Test completed successfully!")
+        logger.info(f"Total particles: {total_particles}")
+        logger.info(f"Flipped particles: {flipped_count} ({flipped_percentage:.1f}%)")
+        logger.info(f"Interactive plot saved as: {output_html}")
+
+        log_test_success(test_name, logger)
+
+    except Exception as e:
+        log_test_failure(test_name, e, logger)
+        raise
+
+
+if __name__ == "__main__":
+    test_find_flipped_particles()
+    print("Test completed successfully!")

--- a/test/unit/test_flip_emc_particles.py
+++ b/test/unit/test_flip_emc_particles.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Test for the flip_emc_particles function in io_utils.
+
+Loads test_data.mat, randomly selects 20% of particles to flip,
+applies the flip_emc_particles function, and saves the result to test_data_flipped.mat.
+"""
+
+import sys
+import random
+import numpy as np
+from pathlib import Path
+
+# Add test utilities to path
+test_root = Path(__file__).parent.parent
+sys.path.insert(0, str(test_root))
+
+from test_utils import (
+    TestConfig,
+    setup_test_logging,
+    get_test_data_path,
+    log_test_start,
+    log_test_success,
+    log_test_failure,
+    setup_test_environment,
+)
+
+setup_test_environment()
+
+from magpiem.io.io_utils import read_emc_mat, write_emc_mat
+
+logger = setup_test_logging()
+
+TEST_DATA_FILE = get_test_data_path(TestConfig.TEST_DATA_STANDARD)
+
+# proportion of particles to flip, chosen randomly
+AMOUNT_TO_FLIP = 0.3
+
+
+def test_flip_emc_particles():
+    """Test the write_emc_mat function with particle flipping functionality."""
+    test_name = "Flip EMC Particles Test"
+    log_test_start(test_name, logger)
+
+    try:
+        logger.info(f"Loading test data from {TEST_DATA_FILE}")
+
+        mat_geom = read_emc_mat(str(TEST_DATA_FILE))
+
+        if mat_geom is None:
+            raise ValueError("Failed to load mat file")
+
+        logger.info(f"Loaded geometry data with {len(mat_geom)} tomograms")
+
+        particles_to_flip = {}
+        total_particles = 0
+        flipped_count = 0
+
+        # Choose random particles to flip in each tomogram
+        for tomo_id, particles in mat_geom.items():
+            if len(particles) == 0:
+                continue
+
+            total_particles += len(particles)
+            num_to_flip = max(1, int(len(particles) * AMOUNT_TO_FLIP))
+            particle_indices = list(range(len(particles)))
+            selected_indices = random.sample(particle_indices, num_to_flip)
+
+            particles_to_flip[tomo_id] = selected_indices
+            flipped_count += len(selected_indices)
+
+            logger.info(
+                f"Tomogram {tomo_id}: {len(particles)} particles, flipping {len(selected_indices)}"
+            )
+
+        logger.info(
+            f"Total particles: {total_particles}, flipping {flipped_count} ({flipped_count/total_particles*100:.1f}%)"
+        )
+
+        # Create keep_ids dict for all particles (since we want to keep all particles, just with some flipped)
+        keep_ids = {}
+        for tomo_id, particles in mat_geom.items():
+            keep_ids[tomo_id] = list(range(len(particles)))
+
+        output_file = test_root / "data" / "test_data_flipped.mat"
+        logger.info(f"Saving flipped data to {output_file}")
+
+        write_emc_mat(
+            keep_ids,
+            str(output_file),
+            str(TEST_DATA_FILE),
+            flip_particles=particles_to_flip,
+        )
+
+        assert output_file.exists(), f"Output file {output_file} was not created"
+
+        # Load created file for some verification
+        logger.info("Verifying flip results...")
+        flipped_mat_geom = read_emc_mat(str(output_file))
+
+        # Ensure no particles were lost
+        for tomo_id, particles in flipped_mat_geom.items():
+            assert len(particles) == len(
+                flipped_mat_geom[tomo_id]
+            ), f"Number of particles in {tomo_id} is not the same as in the original file. Original: {len(mat_geom[tomo_id])}, Flipped: {len(flipped_mat_geom[tomo_id])}"
+
+        log_test_success(test_name, logger)
+        logger.info(f"Flipped data saved to: {output_file}")
+        logger.info(
+            f"Successfully flipped {flipped_count} particles across {len(particles_to_flip)} tomograms"
+        )
+
+    except Exception as e:
+        log_test_failure(test_name, e, logger)
+        raise
+
+
+if __name__ == "__main__":
+    test_flip_emc_particles()
+    print("Test completed successfully!")


### PR DESCRIPTION
- Cleaning optionally detects flipped particles and includes them in lattices
- If desired, plotting can show their positions rectified relative to the majority direction of particles in lattice
- Before saving, each flipped particle can be rotated 180 degrees, correcting its orientation within the file whilst maintaining a proper rotation.